### PR TITLE
Add a constraint to ITextLineChoice['values']

### DIFF
--- a/plone/schemaeditor/schema.py
+++ b/plone/schemaeditor/schema.py
@@ -88,5 +88,6 @@ class ITextLineChoice(interfaces.IField):
         description=_(u'Enter allowed choices one per line.'),
         required=interfaces.IChoice['vocabulary'].required,
         default=interfaces.IChoice['vocabulary'].default,
+        constraint=all,
         value_type=schema.TextLine())
     interface.alsoProvides(values, ITextLinesField)


### PR DESCRIPTION
Adding a constraint -- requiring all values be non-empty -- prevents multiple trailing line feeds from inducing an empty value (a term with no value), but it appears that form normalization / converter tolerates a single (and only one) trailing blankline, by ignoring it.  So this constraint only catches -- in practice -- multiple trailing blank lines in the choices / vocabulary values for the field.
