### PR TITLE
Fix schmaeditor to preserve i18n Message values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 1.3.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add support for non-destructive editing of attributes with i18n
+  Message values
+  [datakurre]
 
 1.3.8 (2014-09-07)
 ------------------

--- a/plone/schemaeditor/browser/field/configure.zcml
+++ b/plone/schemaeditor/browser/field/configure.zcml
@@ -12,6 +12,8 @@
 
     <adapter
         factory=".edit.FieldTitleAdapter" />
+    <adapter
+        factory=".edit.FieldDataManager" />
 
     <browser:page
         name="order"

--- a/plone/schemaeditor/browser/field/edit.py
+++ b/plone/schemaeditor/browser/field/edit.py
@@ -85,14 +85,10 @@ class FieldDataManager(AttributeField):
             old_value = super(FieldDataManager, self).get()
         except (AttributeError, ForbiddenAttribute):
             old_value = None
-        if isinstance(old_value, Message) and old_value.default:
+        if isinstance(old_value, Message):
             value = Message(unicode(old_value),
                             domain=old_value.domain,
                             default=value,
-                            mapping=old_value.mapping)
-        elif isinstance(old_value, Message):
-            value = Message(value,
-                            domain=old_value.domain,
                             mapping=old_value.mapping)
         super(FieldDataManager, self).set(value)
 

--- a/plone/schemaeditor/browser/field/edit.py
+++ b/plone/schemaeditor/browser/field/edit.py
@@ -80,7 +80,7 @@ class FieldDataManager(AttributeField):
         return value
 
     def set(self, value):
-        old_value = super(FieldDataManager, self).get()
+        old_value = super(FieldDataManager, self).query()
         if isinstance(old_value, Message) and old_value.default:
             value = Message(unicode(old_value),
                             domain=old_value.domain,

--- a/plone/schemaeditor/browser/field/edit.py
+++ b/plone/schemaeditor/browser/field/edit.py
@@ -5,6 +5,7 @@ from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import adapts, getAdapters
 from zope.event import notify
 from zope.schema.interfaces import IField
+from zope.security.interfaces import ForbiddenAttribute
 from zope import schema
 from zope.i18nmessageid import Message
 from zope.i18nmessageid import MessageFactory
@@ -80,7 +81,10 @@ class FieldDataManager(AttributeField):
         return value
 
     def set(self, value):
-        old_value = super(FieldDataManager, self).query()
+        try:
+            old_value = super(FieldDataManager, self).get()
+        except (AttributeError, ForbiddenAttribute):
+            old_value = None
         if isinstance(old_value, Message) and old_value.default:
             value = Message(unicode(old_value),
                             domain=old_value.domain,

--- a/plone/schemaeditor/browser/field/edit.py
+++ b/plone/schemaeditor/browser/field/edit.py
@@ -1,14 +1,17 @@
 from Acquisition import aq_parent, aq_inner
 
-from zope.interface import implements, Interface
+from zope.interface import implements, Interface, declarations
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import adapts, getAdapters
 from zope.event import notify
 from zope.schema.interfaces import IField
 from zope import schema
+from zope.i18nmessageid import Message
 from zope.i18nmessageid import MessageFactory
 
 from z3c.form import form, field, button
+from z3c.form.interfaces import IDataManager
+from z3c.form.datamanager import AttributeField
 from plone.z3cform import layout
 from plone.autoform.form import AutoExtensibleForm
 
@@ -47,13 +50,56 @@ class FieldTitleAdapter(object):
     title = property(_read_title, _write_title)
 
 
+class IFieldProxy(Interface):
+    """Marker interface for field being edited by schemaeditor"""
+
+
+class FieldProxy(object):
+    implements(IFieldProxy)
+
+    def __init__(self, context):
+        self.__class__ = type(context.__class__.__name__,
+                              (self.__class__, context.__class__), {})
+        self.__dict__ = context.__dict__
+
+    @property
+    def __provides__(self):
+        return declarations.Provides(self.__class__)
+
+    __providedBy__ = __provides__
+
+
+class FieldDataManager(AttributeField):
+    implements(IDataManager)
+    adapts(IFieldProxy, IField)
+
+    def get(self):
+        value = super(FieldDataManager, self).get()
+        if isinstance(value, Message) and value.default:
+            return value.default
+        return value
+
+    def set(self, value):
+        old_value = super(FieldDataManager, self).get()
+        if isinstance(old_value, Message) and old_value.default:
+            value = Message(unicode(old_value),
+                            domain=old_value.domain,
+                            default=value,
+                            mapping=old_value.mapping)
+        elif isinstance(old_value, Message):
+            value = Message(value,
+                            domain=old_value.domain,
+                            mapping=old_value.mapping)
+        super(FieldDataManager, self).set(value)
+
+
 class FieldEditForm(AutoExtensibleForm, form.EditForm):
     implements(IFieldEditForm)
     id = 'edit-field-form'
 
     def __init__(self, context, request):
         super(form.EditForm, self).__init__(context, request)
-        self.field = context.field
+        self.field = FieldProxy(context.field)
 
     def getContent(self):
         return self.field

--- a/plone/schemaeditor/browser/field/edit.py
+++ b/plone/schemaeditor/browser/field/edit.py
@@ -1,6 +1,8 @@
 from Acquisition import aq_parent, aq_inner
 
-from zope.interface import implements, Interface, declarations
+from zope.interface import implements, Interface
+from zope.interface.declarations import ObjectSpecificationDescriptor
+from zope.interface.declarations import getObjectSpecification
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import adapts, getAdapters
 from zope.event import notify
@@ -55,19 +57,23 @@ class IFieldProxy(Interface):
     """Marker interface for field being edited by schemaeditor"""
 
 
+class FieldProxySpecification(ObjectSpecificationDescriptor):
+    def __get__(self, inst, cls=None):
+        if inst is None:
+            return getObjectSpecification(cls)
+        else:
+            return inst.__provides__
+
+
 class FieldProxy(object):
     implements(IFieldProxy)
+
+    __providedBy__ = FieldProxySpecification()
 
     def __init__(self, context):
         self.__class__ = type(context.__class__.__name__,
                               (self.__class__, context.__class__), {})
         self.__dict__ = context.__dict__
-
-    @property
-    def __provides__(self):
-        return declarations.Provides(self.__class__)
-
-    __providedBy__ = __provides__
 
 
 class FieldDataManager(AttributeField):

--- a/plone/schemaeditor/tests/editing.txt
+++ b/plone/schemaeditor/tests/editing.txt
@@ -133,6 +133,13 @@ value was set::
     >>> IDummySchema['favorite_color'].description.default
     u'Enter your favorite color.'
 
+Let's also check that the the support for editing i18n Message values does not
+persist its marker interface::
+
+    >>> from plone.schemaeditor.browser.field.edit import IFieldProxy
+    >>> IFieldProxy.providedBy(IDummySchema['favorite_color'])
+    False
+
 Let's go back and try to make an invalid change.  The form won't let us::
 
     >>> browser.getLink(url='favorite_color').click()

--- a/plone/schemaeditor/tests/editing.txt
+++ b/plone/schemaeditor/tests/editing.txt
@@ -133,7 +133,7 @@ value was set::
     >>> IDummySchema['favorite_color'].description.default
     u'Enter your favorite color.'
 
-Let's also check that the the support for editing i18n Message values does not
+Let's also check that the support for editing i18n Message values does not
 persist its marker interface::
 
     >>> from plone.schemaeditor.browser.field.edit import IFieldProxy

--- a/plone/schemaeditor/tests/editing.txt
+++ b/plone/schemaeditor/tests/editing.txt
@@ -98,6 +98,41 @@ Let's confirm that the new default value was correctly saved to the actual schem
     >>> IDummySchema['favorite_color'].description
     u'Enter your favorite color.'
 
+If the schema is edited to have internationalized attributes::
+
+    >>> from zope.i18nmessageid import Message
+    >>> IDummySchema['favorite_color'].description = Message(
+    ...    'favorite_color', domain='plone.schemaeditor')
+
+Then editing the schema will preserve those values and only update their
+default values::
+
+    >>> browser.getLink(url='favorite_color').click()
+    >>> browser.url
+    'http://nohost/@@schemaeditor/favorite_color'
+    >>> "Edit Field 'favorite_color'" in browser.contents
+    True
+    >>> browser.getControl('Description').value
+    'favorite_color'
+    >>> browser.getControl('Description').value = 'Enter your favorite color.'
+    >>> browser.getControl('Save').click()
+    [event: ObjectModifiedEvent on TextLine]
+    [event: SchemaModifiedEvent on DummySchemaContext]
+    >>> browser.url
+    'http://nohost/@@schemaeditor'
+
+Let's confirm that the message value was preserved and only its default
+value was set::
+
+    >>> type(IDummySchema['favorite_color'].description)
+    <type 'zope.i18nmessageid.message.Message'>
+    >>> IDummySchema['favorite_color'].description
+    u'favorite_color'
+    >>> IDummySchema['favorite_color'].description.domain
+    'plone.schemaeditor'
+    >>> IDummySchema['favorite_color'].description.default
+    u'Enter your favorite color.'
+
 Let's go back and try to make an invalid change.  The form won't let us::
 
     >>> browser.getLink(url='favorite_color').click()


### PR DESCRIPTION
A couple of todo to merge:

- fix to always edit the default value (editing message id may not make sense)
- tests (that Message is preserved and wrapper does not have side effects)

And then there will be also a pull for master.

Yet, comments about the approach is welcome. It's not nice that I have to wrap a field to register a custom data manager for it, but could not figure out any simpler (and as generic) way yet.