### PR TITLE
Add a "protected" method to IFieldFactory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ Changelog
   Message values
   [datakurre]
 
+- Add a "protected" method to IFieldFactory that may be used to determine
+  if a particular field must be non editable and not movable using the editor
+  (just like a behavior field).
+  Override it for custom behavior in a subclass.
+  [ebrehault]
 
 2.0.4 (2015-05-13)
 ------------------

--- a/plone/schemaeditor/browser/schema/listing.py
+++ b/plone/schemaeditor/browser/schema/listing.py
@@ -71,7 +71,7 @@ class SchemaListing(AutoExtensibleForm, form.Form):
         field_identifier = u'%s.%s' % (
             field.__module__, field.__class__.__name__)
         field_factory = queryUtility(IFieldFactory, name=field_identifier)
-        return field_factory.protected(field)
+        return field_factory and field_factory.protected(field)
 
     def edit_url(self, field):
         field_factory = self._field_factory(field)

--- a/plone/schemaeditor/browser/schema/listing.py
+++ b/plone/schemaeditor/browser/schema/listing.py
@@ -67,6 +67,12 @@ class SchemaListing(AutoExtensibleForm, form.Form):
         else:
             return field.__class__.__name__
 
+    def protected_field(self, field):
+        field_identifier = u'%s.%s' % (
+            field.__module__, field.__class__.__name__)
+        field_factory = queryUtility(IFieldFactory, name=field_identifier)
+        return field_factory and field_factory.protected(field)
+
     def edit_url(self, field):
         field_factory = self._field_factory(field)
         if field_factory is not None and field_factory.editable(field):

--- a/plone/schemaeditor/browser/schema/schema_listing.pt
+++ b/plone/schemaeditor/browser/schema/schema_listing.pt
@@ -92,48 +92,53 @@
           </tal:block>
 
           <tal:widgets repeat="widget group/widgets/values">
+            <tal:block
+              tal:define="
+                disabled widget/disabled|nothing;
+                protected python:view.protected_field(widget.field);">
 
-            <div tal:condition="widget/disabled|nothing" class="fieldPreview fieldFromBehavior">
-              <div class="fieldLabel">
-                  <tal:block i18n:translate="">From the
-                    <tal:block i18n:name="behavior_name" tal:replace="python:widget.__name__.split('.')[0]"/> behavior:</tal:block>
-                  <strong tal:content="widget/field/__name__" /> &ndash;
-                  <tal:block tal:content="python:view.field_type(widget.field)"/>
-              </div>
-              <tal:field tal:replace="structure widget/@@ploneform-render-widget" />
-              <div class="disabled-field-overlay"></div>
-            </div>
-
-            <div tal:condition="not:widget/disabled|nothing"
-                 class="fieldPreview orderable" tal:attributes="data-field_id widget/field/__name__">
-
-              <div class="fieldLabel">
-                  <strong tal:content="widget/field/__name__" /> &ndash;
-                  <tal:block tal:content="python:view.field_type(widget.field)"/>
-              </div>
-
-              <div class="fieldControls"
-                   i18n:domain="plone.schemaeditor">
-                  <a class="fieldSettings pat-plone-modal"
-                     tal:define="edit_url python:view.edit_url(widget.field)"
-                     tal:condition="edit_url"
-                     i18n:translate=""
-                     tal:attributes="href edit_url">Settings&hellip;</a>
-                  <a class="schemaeditor-delete-field"
-                     i18n:attributes="title; data-confirm_msg"
-                     title="Delete field"
-                     data-confirm_msg="Are you sure you want to delete this field?"
-                     style="margin-left: 1em; font-size: 150%; border: none"
-                     tal:define="delete_url python:view.delete_url(widget.field)"
-                     tal:condition="delete_url"
-                     tal:attributes="href delete_url">&times;</a>
-              </div>
-
-              <div style="width: 80%">
+              <div tal:condition="python:disabled or protected" class="fieldPreview fieldFromBehavior">
+                <div class="fieldLabel">
+                    <tal:block tal:condition="disabled" i18n:translate="">From the
+                      <tal:block i18n:name="behavior_name" tal:replace="python:widget.__name__.split('.')[0]"/> behavior:</tal:block>
+                    <strong tal:content="widget/field/__name__" /> &ndash;
+                    <tal:block tal:content="python:view.field_type(widget.field)"/>
+                </div>
                 <tal:field tal:replace="structure widget/@@ploneform-render-widget" />
+                <div class="disabled-field-overlay"></div>
               </div>
 
-            </div>
+              <div tal:condition="python:not(disabled or protected)"
+                   class="fieldPreview orderable" tal:attributes="data-field_id widget/field/__name__">
+
+                <div class="fieldLabel">
+                    <strong tal:content="widget/field/__name__" /> &ndash;
+                    <tal:block tal:content="python:view.field_type(widget.field)"/>
+                </div>
+
+                <div class="fieldControls"
+                     i18n:domain="plone.schemaeditor">
+                    <a class="fieldSettings pat-plone-modal"
+                       tal:define="edit_url python:view.edit_url(widget.field)"
+                       tal:condition="edit_url"
+                       i18n:translate=""
+                       tal:attributes="href edit_url">Settings&hellip;</a>
+                    <a class="schemaeditor-delete-field"
+                       i18n:attributes="title; data-confirm_msg"
+                       title="Delete field"
+                       data-confirm_msg="Are you sure you want to delete this field?"
+                       style="margin-left: 1em; font-size: 150%; border: none"
+                       tal:define="delete_url python:view.delete_url(widget.field)"
+                       tal:condition="delete_url"
+                       tal:attributes="href delete_url">&times;</a>
+                </div>
+
+                <div style="width: 80%">
+                  <tal:field tal:replace="structure widget/@@ploneform-render-widget" />
+                </div>
+
+              </div>
+            </tal:block>
 
           </tal:widgets>
 

--- a/plone/schemaeditor/fields.py
+++ b/plone/schemaeditor/fields.py
@@ -52,6 +52,10 @@ class FieldFactory(object):
         """ test whether a given instance of a field is editable """
         return True
 
+    def protected(self, field):
+        """ test whether a given instance of a field is protected """
+        return False
+
 
 def FieldsVocabularyFactory(context):
     request = getRequest()

--- a/plone/schemaeditor/interfaces.py
+++ b/plone/schemaeditor/interfaces.py
@@ -79,6 +79,9 @@ class IFieldFactory(IField):
     def editable(self, field):
         """ test whether a given instance of a field is editable """
 
+    def protected(self, field):
+        """ test whether a given instance of a field is protected """
+
 
 class IEditableSchema(Interface):
 


### PR DESCRIPTION
`protected()` will return `False` by default, but by overriding it in a custom subclass, we can get the same rendering as a behavior field (= not editable and not draggable) for any field we want.