### PR TITLE
Display status message in parent window after modal close

### DIFF
--- a/plone/schemaeditor/browser/field/edit.pt
+++ b/plone/schemaeditor/browser/field/edit.pt
@@ -1,0 +1,14 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      i18n:domain="plone">
+
+<body>
+    <h1 class="documentFirstHeading" tal:content="view/label"></h1>
+    <div id="content">
+        <tal:block tal:replace="structure view/contents|view/render"/>
+    </div>
+</body>
+</html>

--- a/plone/schemaeditor/browser/schema/add.pt
+++ b/plone/schemaeditor/browser/schema/add.pt
@@ -1,0 +1,14 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      i18n:domain="plone">
+
+<body>
+    <h1 class="documentFirstHeading" tal:content="view/label"></h1>
+    <div id="content">
+        <tal:block tal:replace="structure view/contents|view/render"/>
+    </div>
+</body>
+</html>

--- a/plone/schemaeditor/browser/schema/add_field.py
+++ b/plone/schemaeditor/browser/schema/add_field.py
@@ -4,6 +4,8 @@ from zope.lifecycleevent import ObjectAddedEvent
 from z3c.form import form, field
 from z3c.form.interfaces import WidgetActionExecutionError
 from plone.z3cform.layout import wrap_form
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.statusmessages.interfaces import IStatusMessage
 
 from plone.schemaeditor import SchemaEditorMessageFactory as _
 from plone.schemaeditor.interfaces import INewField
@@ -44,12 +46,14 @@ class FieldAddForm(form.AddForm):
         schema.moveField(field.__name__, position)
         notify(ObjectAddedEvent(field, context.schema))
         notify(FieldAddedEvent(context, field))
-        self.status = _(u"Field added successfully.")
+        IStatusMessage(self.request).addStatusMessage(
+            _(u"Field added successfully."), type='info')
 
     def nextURL(self):
-        url = self.context.absolute_url()
-        if getattr(self.context, 'schemaEditorView', None) is not None:
-            url += '/@@' + self.context.schemaEditorView
-        return url
+        return "@@add-field"
 
-FieldAddFormPage = wrap_form(FieldAddForm)
+
+FieldAddFormPage = wrap_form(
+    FieldAddForm,
+    index=ViewPageTemplateFile('add.pt')
+)

--- a/plone/schemaeditor/browser/schema/add_fieldset.py
+++ b/plone/schemaeditor/browser/schema/add_fieldset.py
@@ -5,6 +5,8 @@ from zope.container.contained import notifyContainerModified
 from z3c.form import form, field
 from z3c.form.interfaces import WidgetActionExecutionError
 from plone.z3cform.layout import wrap_form
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.statusmessages.interfaces import IStatusMessage
 
 from plone.schemaeditor import SchemaEditorMessageFactory as _
 from plone.schemaeditor.interfaces import INewFieldset
@@ -35,13 +37,14 @@ class FieldsetAddForm(form.AddForm):
         schema.setTaggedValue(FIELDSETS_KEY, fieldsets)
         notifyContainerModified(schema)
         notify(SchemaModifiedEvent(self.context))
-        self.status = _(u"Fieldset added successfully.")
+        IStatusMessage(self.request).addStatusMessage(
+            _(u"Fieldset added successfully."), type='info')
 
     def nextURL(self):
-        url = self.context.absolute_url()
-        if getattr(self.context, 'schemaEditorView', None) is not None:
-            url += '/@@' + self.context.schemaEditorView
+        return "@@add-fieldset"
 
-        return url
 
-FieldsetAddFormPage = wrap_form(FieldsetAddForm)
+FieldsetAddFormPage = wrap_form(
+    FieldsetAddForm,
+    index=ViewPageTemplateFile('add.pt')
+)

--- a/plone/schemaeditor/configure.zcml
+++ b/plone/schemaeditor/configure.zcml
@@ -6,6 +6,7 @@
 
     <include package="plone.z3cform"/>
     <include package="plone.protect" />
+    <include package="Products.statusmessages" />
 
     <i18n:registerTranslations directory="locales"/>
 

--- a/plone/schemaeditor/tests/choice.txt
+++ b/plone/schemaeditor/tests/choice.txt
@@ -37,10 +37,11 @@ Add a Choice field.
     [event: ObjectAddedEvent on Choice]
     [event: FieldAddedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/@@add-field'
 
 Open the new fields edit form.
 
+    >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='country').click()
 
 The edit form for choice fields includes a widget for specifying the
@@ -145,10 +146,11 @@ Add a Choice field.
     [event: ObjectAddedEvent on Set]
     [event: FieldAddedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/@@add-field'
 
 Open the new fields edit form.
 
+    >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='categories').click()
 
 The edit form for choice fields includes a widget for specifying the

--- a/plone/schemaeditor/tests/editing.txt
+++ b/plone/schemaeditor/tests/editing.txt
@@ -49,7 +49,7 @@ Let's add a 'favorite-color' field to the IDummySchema schema::
     [event: ObjectAddedEvent on TextLine]
     [event: FieldAddedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/@@add-field'
 
 Now the actual IDummySchema schema should have the new field (the field id is a
 normalized form of the title)::
@@ -73,6 +73,7 @@ Editing a schema field attribute
 
 Let's navigate to the 'favorite-color' field we just created::
 
+    >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='favorite_color').click()
     >>> browser.url
     'http://nohost/@@schemaeditor/favorite_color'
@@ -91,7 +92,7 @@ of schema fields, which should reflect the change::
     [event: ObjectModifiedEvent on TextLine]
     [event: SchemaModifiedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/favorite_color/@@edit'
 
 Let's confirm that the new default value was correctly saved to the actual schema::
 
@@ -107,6 +108,7 @@ If the schema is edited to have internationalized attributes::
 Then editing the schema will preserve those values and only update their
 default values::
 
+    >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='favorite_color').click()
     >>> browser.url
     'http://nohost/@@schemaeditor/favorite_color'
@@ -119,7 +121,7 @@ default values::
     [event: ObjectModifiedEvent on TextLine]
     [event: SchemaModifiedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/favorite_color/@@edit'
 
 Let's confirm that the message value was preserved and only its default
 value was set::
@@ -142,6 +144,7 @@ persist its marker interface::
 
 Let's go back and try to make an invalid change.  The form won't let us::
 
+    >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='favorite_color').click()
     >>> browser.url
     'http://nohost/@@schemaeditor/favorite_color'
@@ -329,7 +332,7 @@ Let's add a 'extra-info' fieldset to the IDummySchema schema::
     [event: ContainerModifiedEvent on InterfaceClass]
     [event: SchemaModifiedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/@@add-fieldset'
 
 Now the actual IDummySchema schema should have the new fieldset ::
 
@@ -357,7 +360,7 @@ and saved.
     ...     browser.getControl('Short Name').value = field_id
     ...     browser.getControl('Field type').value = [factory.title]
     ...     browser.getControl('Add').click()
-    ...     assert browser.url == portal_url + '/@@schemaeditor', (
+    ...     assert browser.url == portal_url + '/@@schemaeditor/@@add-field', (
     ...         'Failed to create %r' % name)
     ...     assert field_id in schema, '%r not in %r' % (
     ...         field_id, schema)
@@ -365,6 +368,7 @@ and saved.
     ...         schema[field_id], factory.fieldcls
     ...         ), '%r is not an instance of %r' % (
     ...             schema[field_id], factory.fieldcls)
+    ...     browser.open(portal_url + '/@@schemaeditor')
     ...     browser.getLink(url=field_id).click()
     ...     browser.getControl('Title').value += ' '
     ...     browser.getControl('Save').click()
@@ -437,4 +441,4 @@ these fields, they are allowed as long as the field is of the correct type.
     [event: ObjectAddedEvent on TextLine]
     [event: FieldAddedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/@@add-field'

--- a/plone/schemaeditor/tests/minmax.txt
+++ b/plone/schemaeditor/tests/minmax.txt
@@ -35,10 +35,11 @@ Add an Int field.
     [event: ObjectAddedEvent on Int]
     [event: FieldAddedEvent on DummySchemaContext]
     >>> browser.url
-    'http://nohost/@@schemaeditor'
+    'http://nohost/@@schemaeditor/@@add-field'
 
 Open the new fields edit form.
 
+    >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='age').click()
 
 Set the range to 13 to 100.
@@ -51,6 +52,7 @@ Set the range to 13 to 100.
 
 Return to the form and set the range to values outside the current range.
 
+    >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='age').click()
     >>> browser.getControl(name='form.widgets.min').value = '0'
     >>> browser.getControl(name='form.widgets.max').value = '200'


### PR DESCRIPTION
@vangheem @davisagli : it appears we could not safely remove modals here (too many technical + UI consequences). So here is my fix:
- messages that must be displayed in the parent window are produced using `Products.statusmessages`, messages that must appear in the modals are still produce using `self.status`,
- after adding or editing a field, we do not redirect to parent (that would burn the status messages), as the modal will reload the parent window anyway,
- we do not use the main template anymore to display add and edit forms, so it does not burn the `Products.statusmessages` messages.

@tisto, 2 bad news for you:
- we keep the modals,
- it does break the tests in p.a.users, p.a.dexterity and p.schemaeditor because it seems the BrowserTest requests cannot be adapted to create portal messages `IStatusMessage(self.request).addStatusMessage`, is there something special we must do?