### PR TITLE
Supports additionalSchemata in field Add form 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Supports additionalSchemata in field Add form
+  [ebrehault]
 
 
 2.0.5 (2015-06-05)


### PR DESCRIPTION
Extra fields providing IFieldEditorExtender are displayed in the field Add form, and the submitted values are stored in the newly created instance.

Note: I am not very confident about my changes in the `FieldAddForm.create` method, if anybody having a good knowledge of this module (@davisagli or @tdesvenain maybe?), it would be nice.