### PR TITLE
addTokenToUrl soft dependency 2nd try

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make ``plone.protect.utils.addTokenToUrl`` a soft dependency, making this
+  package usable in Plone < 5.0.
+  [thet]
 
 
 2.0.6 (2015-07-18)

--- a/plone/schemaeditor/browser/schema/listing.py
+++ b/plone/schemaeditor/browser/schema/listing.py
@@ -7,12 +7,17 @@ from z3c.form.interfaces import IEditForm, DISPLAY_MODE
 from plone.z3cform.layout import FormWrapper
 from plone.memoize.instance import memoize
 from plone.autoform.form import AutoExtensibleForm
-from plone.protect.utils import addTokenToUrl
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 from plone.schemaeditor import SchemaEditorMessageFactory as _
 from plone.schemaeditor.interfaces import IFieldFactory
 from plone.schemaeditor.utils import SchemaModifiedEvent
+
+try:
+    from plone.protect.utils import addTokenToUrl
+except ImportError:
+    addTokenToUrl = None
+
 
 
 class SchemaListing(AutoExtensibleForm, form.Form):
@@ -83,7 +88,8 @@ class SchemaListing(AutoExtensibleForm, form.Form):
         if field.__name__ in self.context.fieldsWhichCannotBeDeleted:
             return
         url = '%s/%s/@@delete' % (self.context.absolute_url(), field.__name__)
-        url = addTokenToUrl(url, self.request)
+        if addTokenToUrl:
+            url = addTokenToUrl(url, self.request)
         return url
 
     @button.buttonAndHandler(


### PR DESCRIPTION
Make ``plone.protect.utils.addTokenToUrl`` a soft dependency, making this package usable in Plone < 5.0.