### PR TITLE
Use plone i18n domain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Use plone domain for translations.
+  [gforcada]
 
 
 2.0.7 (2015-09-07)

--- a/plone/schemaeditor/__init__.py
+++ b/plone/schemaeditor/__init__.py
@@ -1,2 +1,4 @@
 from zope.i18nmessageid import MessageFactory
-SchemaEditorMessageFactory = MessageFactory('plone.schemaeditor')
+
+
+_ = MessageFactory('plone')

--- a/plone/schemaeditor/browser/configure.zcml
+++ b/plone/schemaeditor/browser/configure.zcml
@@ -1,7 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="plone.schemaeditor">
+    i18n_domain="plone">
 
     <include package=".field"/>
     <include package=".schema" />

--- a/plone/schemaeditor/browser/field/configure.zcml
+++ b/plone/schemaeditor/browser/field/configure.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="plone.app.dexterity">
+    i18n_domain="plone">
 
     <browser:page
         name="edit"

--- a/plone/schemaeditor/browser/field/edit.py
+++ b/plone/schemaeditor/browser/field/edit.py
@@ -10,7 +10,6 @@ from zope.schema.interfaces import IField
 from zope.security.interfaces import ForbiddenAttribute
 from zope import schema
 from zope.i18nmessageid import Message
-from zope.i18nmessageid import MessageFactory
 
 from z3c.form import form, field, button
 from z3c.form.interfaces import IDataManager
@@ -23,10 +22,8 @@ from Products.statusmessages.interfaces import IStatusMessage
 from plone.schemaeditor.interfaces import IFieldEditForm
 from plone.schemaeditor import interfaces
 from plone.schemaeditor.utils import SchemaModifiedEvent
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.schemaeditor import _
 
-
-PMF = MessageFactory('plone')
 
 _marker = object()
 
@@ -142,7 +139,7 @@ class FieldEditForm(AutoExtensibleForm, form.EditForm):
 
         self.updateFieldsFromSchemata()
 
-    @button.buttonAndHandler(PMF(u'Save'), name='save')
+    @button.buttonAndHandler(_(u'Save'), name='save')
     def handleSave(self, action):
         data, errors = self.extractData()
         if errors:
@@ -166,7 +163,7 @@ class FieldEditForm(AutoExtensibleForm, form.EditForm):
 
         notify(SchemaModifiedEvent(self.context.aq_parent))
 
-    @button.buttonAndHandler(PMF(u'Cancel'), name='cancel')
+    @button.buttonAndHandler(_(u'Cancel'), name='cancel')
     def handleCancel(self, action):
         self.redirectToParent()
 

--- a/plone/schemaeditor/browser/schema/add_field.py
+++ b/plone/schemaeditor/browser/schema/add_field.py
@@ -10,7 +10,7 @@ from plone.z3cform.layout import wrap_form
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.schemaeditor import _
 from plone.schemaeditor import interfaces
 from plone.schemaeditor.utils import IEditableSchema, non_fieldset_fields,\
     sortedFields

--- a/plone/schemaeditor/browser/schema/add_fieldset.py
+++ b/plone/schemaeditor/browser/schema/add_fieldset.py
@@ -8,7 +8,7 @@ from plone.z3cform.layout import wrap_form
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.schemaeditor import _
 from plone.schemaeditor.interfaces import INewFieldset
 from plone.schemaeditor.utils import SchemaModifiedEvent
 from plone.supermodel.model import Fieldset

--- a/plone/schemaeditor/browser/schema/configure.zcml
+++ b/plone/schemaeditor/browser/schema/configure.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="plone.schemaeditor">
+    i18n_domain="plone">
 
   <browser:page
       name="edit"

--- a/plone/schemaeditor/browser/schema/listing.py
+++ b/plone/schemaeditor/browser/schema/listing.py
@@ -9,7 +9,7 @@ from plone.memoize.instance import memoize
 from plone.autoform.form import AutoExtensibleForm
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.schemaeditor import _
 from plone.schemaeditor.interfaces import IFieldFactory
 from plone.schemaeditor.utils import SchemaModifiedEvent
 

--- a/plone/schemaeditor/browser/schema/schema_listing.pt
+++ b/plone/schemaeditor/browser/schema/schema_listing.pt
@@ -1,7 +1,7 @@
 <div xmlns:tal="http://xml.zope.org/namespaces/tal"
      xmlns:metal="http://xml.zope.org/namespaces/metal"
      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-     tal:omit-tag="" i18n:domain="plone.schemaeditor">
+     tal:omit-tag="" i18n:domain="plone">
   <a id="add-field" class="pat-plone-modal"
      href="${context/absolute_url}/@@add-field">
     <button style="float: right; display: block;"
@@ -116,8 +116,7 @@
                     <tal:block tal:content="python:view.field_type(widget.field)"/>
                 </div>
 
-                <div class="fieldControls"
-                     i18n:domain="plone.schemaeditor">
+                <div class="fieldControls">
                     <a class="fieldSettings pat-plone-modal"
                        tal:define="edit_url python:view.edit_url(widget.field)"
                        tal:condition="edit_url"

--- a/plone/schemaeditor/configure.zcml
+++ b/plone/schemaeditor/configure.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    i18n_domain="plone.schemaeditor">
+    i18n_domain="plone">
 
     <include package="plone.z3cform"/>
     <include package="plone.protect" />

--- a/plone/schemaeditor/fields.py
+++ b/plone/schemaeditor/fields.py
@@ -16,7 +16,7 @@ from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from z3c.form import validator
 
 from plone.schemaeditor.interfaces import IFieldFactory
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.schemaeditor import _
 from plone.schemaeditor import interfaces
 from plone.schemaeditor import schema as se_schema
 

--- a/plone/schemaeditor/fields.zcml
+++ b/plone/schemaeditor/fields.zcml
@@ -1,6 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="plone.schemaeditor">
+    i18n_domain="plone">
 
   <adapter factory=".fields.getFirstFieldSchema" />
 

--- a/plone/schemaeditor/interfaces.py
+++ b/plone/schemaeditor/interfaces.py
@@ -7,7 +7,7 @@ from zope.schema import Object, TextLine, Text, Choice, ASCIILine, Bool
 from zope.schema.interfaces import IField
 from z3c.form.interfaces import IEditForm
 from OFS.interfaces import IItem
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.schemaeditor import _
 
 
 class ISchemaView(IBrowserPage):

--- a/plone/schemaeditor/locales/update.sh
+++ b/plone/schemaeditor/locales/update.sh
@@ -1,3 +1,0 @@
-domain=plone.schemaeditor
-i18ndude rebuild-pot --pot $domain.pot --create $domain ../
-i18ndude sync --pot $domain.pot */LC_MESSAGES/$domain.po

--- a/plone/schemaeditor/schema.py
+++ b/plone/schemaeditor/schema.py
@@ -17,7 +17,7 @@ except ImportError:
         IDatetime = interfaces.IDatetime
         IDate = interfaces.IDate
 
-from plone.schemaeditor import SchemaEditorMessageFactory as _
+from plone.schemaeditor import _
 
 
 # get rid of unhelpful help text

--- a/plone/schemaeditor/tests/editing.txt
+++ b/plone/schemaeditor/tests/editing.txt
@@ -103,7 +103,7 @@ If the schema is edited to have internationalized attributes::
 
     >>> from zope.i18nmessageid import Message
     >>> IDummySchema['favorite_color'].description = Message(
-    ...    'favorite_color', domain='plone.schemaeditor')
+    ...    'favorite_color', domain='plone')
 
 Then editing the schema will preserve those values and only update their
 default values::

--- a/plone/schemaeditor/tests/robot_testing.zcml
+++ b/plone/schemaeditor/tests/robot_testing.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:gs="http://namespaces.zope.org/genericsetup"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="plone.schemaeditor">
+    i18n_domain="plone">
 
     <include package="plone.schemaeditor"/>
 


### PR DESCRIPTION
plone.schemaeditor is an official Plone core package,
thus their translations belong to plone.app.locales.

This commit removes the plone.schemaeditor domain and changes it for
plone.

This fixes:
https://github.com/plone/plone.schemaeditor/issues/34

Note that this needs to be merged together with a pull request on plone.app.dexterity as both packages depend on each other when it comes to translations.