### PR TITLE
CSRF fixes in Plone 4 for plone.protect 3.0.x integration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,15 @@ Changelog
 1.3.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Backport CSRF protection from plone.schemaeditor 2.0.2, for AJAX
+  compatibility with plone.protect 3.0.x in Plone 4.3.x.
+  [seanupton]
+
+- Fix for cases where _authenticator is injected into the
+  querystring of the URL; in such cases, we get appropriate base URL.
+  This may be particular to use of plone.protect 3.0.x in Plone 4, in
+  some circumstances.
+  [seanupton]
 
 
 1.3.11 (2015-08-14)

--- a/plone/schemaeditor/browser/schema/schema_listing.pt
+++ b/plone/schemaeditor/browser/schema/schema_listing.pt
@@ -18,6 +18,7 @@
 
   <metal:form metal:use-macro="context/@@ploneform-macros/form">
     <metal:top-slot metal:fill-slot="formtop">
+      <input tal:replace="structure context/@@authenticator/authenticator" />
       <script type="text/javascript"
               tal:attributes="src context/++resource++schemaeditor.js"></script>
       <style type="text/css">

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -132,7 +132,8 @@
         $('<span class="draghandle">&#x28FF;</span>').css('cursor', 'ns-resize').prependTo('.fieldPreview.orderable .fieldLabel');
     };
     $(function () {
-        var common_content_filter = '#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info';
+        var common_content_filter = '#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
+            baseURL = window.location.href.split('?')[0];
         // delete field
         $('a.schemaeditor-delete-field').click(function (e) {
             var trigger = $(this);
@@ -140,20 +141,26 @@
             if (!confirm(trigger.attr('data-confirm_msg'))) {
                 return;
             }
-            $.post(trigger.attr('href'), null, function (data) {
+            $.post(trigger.attr('href'), {
+                _authenticator: $('input[name="_authenticator"]').val(),
+            }, function (data) {
                 trigger.closest('.fieldPreview').detach();
             }, 'text');
         });
         // reorder fields and change fieldsets
         $('.fieldPreview.orderable').plone_schemaeditor_html5_sortable(function (position, fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
+            var url = baseURL.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
             $.post(url, {
+                _authenticator: $('input[name="_authenticator"]').val(),
                 pos: position,
                 fieldset_index: fieldset_index
             });
         }, function (fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
-            $.post(url, { fieldset_index: fieldset_index });
+            var url = baseURL.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
+            $.post(url, {
+                _authenticator: $('input[name="_authenticator"]').val(),
+                fieldset_index: fieldset_index
+            });
         });
         // field settings form
         $('a.fieldSettings').prepOverlay({


### PR DESCRIPTION
...of plone.schemaeditor 1.3.x. in Plone 4.3.x.  Without these schema editor will not work with a Plone 4 site with _authenticator token in query string.