### PR TITLE
1.3.x compatibility backports; with both mockup 2.x and plone.protect 3.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.3.12 (unreleased)
 -------------------
 
+- Backport field reorder compatbility fixes from 2.0.3 for jquery.event
+  drag and drop (vangheem).
+  [seanupton]
+
 - Backport CSRF protection from plone.schemaeditor 2.0.2, for AJAX
   compatibility with plone.protect 3.0.x in Plone 4.3.x.
   [seanupton]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.12 (unreleased)
 -------------------
 
+- Backport doctest (functional/browser) fix for choices from 2.0.
+  [seanupton]
+
 - Auto-include plone.protect in ZCML, so that tests will run (backport).
   [seanupton]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.12 (unreleased)
 -------------------
 
+- Auto-include plone.protect in ZCML, so that tests will run (backport).
+  [seanupton]
+
 - Use window.href.pathname for re-order URL construction, to avoid muddled
   URL concatenation conflicting with authenticator token possibly in
   querystring.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,15 @@ Changelog
 1.3.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Backport CSRF protection from plone.schemaeditor 2.0.2, for AJAX
+  compatibility with plone.protect 3.0.x in Plone 4.3.x.
+  [seanupton]
+
+- Fix for cases where _authenticator is injected into the
+  querystring of the URL; in such cases, we get appropriate base URL.
+  This may be particular to use of plone.protect 3.0.x in Plone 4, in
+  some circumstances.
+  [seanupton]
 
 
 1.3.11 (2015-08-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 1.3.12 (unreleased)
 -------------------
 
+- Use window.href.pathname for re-order URL construction, to avoid muddled
+  URL concatenation conflicting with authenticator token possibly in
+  querystring.
+  [seanupton]
+
+- Removed debugger statement from schemaeditor.js.
+  [seanupton]
+
 - Backport field reorder compatbility fixes from 2.0.3 for jquery.event
   drag and drop (vangheem).
   [seanupton]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.3.12 (unreleased)
 -------------------
 
+- Make tests and mocks for plone keyring work fine for both plone.protect
+  2.x and 3.x.  This required adding test dependency on lxml, as
+  plone.protect 3.x transform outputs HTML varying from 2.x.
+  [seanupton]
+
 - Backport doctest (functional/browser) fix for choices from 2.0.
   [seanupton]
 

--- a/plone/schemaeditor/browser/schema/schema_listing.pt
+++ b/plone/schemaeditor/browser/schema/schema_listing.pt
@@ -18,6 +18,7 @@
 
   <metal:form metal:use-macro="context/@@ploneform-macros/form">
     <metal:top-slot metal:fill-slot="formtop">
+      <input tal:replace="structure context/@@authenticator/authenticator" />
       <script type="text/javascript"
               tal:attributes="src context/++resource++schemaeditor.js"></script>
       <style type="text/css">

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -132,7 +132,8 @@
         $('<span class="draghandle">&#x28FF;</span>').css('cursor', 'ns-resize').prependTo('.fieldPreview.orderable .fieldLabel');
     };
     $(function () {
-        var common_content_filter = '#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info';
+        var common_content_filter = '#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
+            baseURL = window.location.href.split('?')[0];
         // delete field
         $('a.schemaeditor-delete-field').click(function (e) {
             var trigger = $(this);
@@ -140,20 +141,26 @@
             if (!confirm(trigger.attr('data-confirm_msg'))) {
                 return;
             }
-            $.post(trigger.attr('href'), null, function (data) {
+            $.post(trigger.attr('href'), {
+                _authenticator: $('input[name="_authenticator"]').val(),
+            }, function (data) {
                 trigger.closest('.fieldPreview').detach();
             }, 'text');
         });
         // reorder fields and change fieldsets
         $('.fieldPreview.orderable').plone_schemaeditor_html5_sortable(function (position, fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
+            var url = baseURL.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
             $.post(url, {
+                _authenticator: $('input[name="_authenticator"]').val(),
                 pos: position,
                 fieldset_index: fieldset_index
             });
         }, function (fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
-            $.post(url, { fieldset_index: fieldset_index });
+            var url = baseURL.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
+            $.post(url, {
+                _authenticator: $('input[name="_authenticator"]').val(),
+                fieldset_index: fieldset_index
+            });
         });
         // field settings form
         $('a.fieldSettings').prepOverlay({

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -2,8 +2,10 @@
   plusplus: true, bitwise: true, regexp: false, indent: 4 */
 /*globals jQuery, confirm */
 (function ($) {
+    'use strict';
+
     $.plone_schemaeditor_normalize_string = function (s) {
-        var s = s.toLowerCase();
+        s = s.toLowerCase();
         var rules = {
                 'a': /[àáâãäå]/g,
                 'ae': /[æ]/g,
@@ -30,58 +32,65 @@
          */
         this.attr('draggable', 'true').css('-webkit-user-drag', 'element').each(function (i) {
             $(this).attr('data-drag_id', i);
-        }).bind('dragstart', function (e) {
-            e.originalEvent.dataTransfer.setData('Text', $(this).attr('data-drag_id'));
-            e.originalEvent.dataTransfer.setData('draggable', true);
-            $('<div id="drop-marker" style="position: absolute; width: 100%;"></div>').insertBefore(this);
-        }).bind('dragenter', function (e) {
-            return false;
-        }).bind('dragleave', function (e) {
-            return false;
-        }).bind('dragover', function (e) {
-            var position = $(this).position(), height = $(this).height(), marker = $('#drop-marker');
-            marker.css('border-bottom', '5px dotted red');
-            if (e.pageY < $(this).offset().top + height / 2) {
-                marker.css('top', position.top + 1 + 'px');
-                $(this).attr('draghalf', 'top');
-            } else {
-                marker.css('top', position.top + height + 21 + 'px');
-                $(this).attr('draghalf', 'bottom');
-            }
-            // window autoscroll
-            if (!$('html,body').is(':animated')) {
-                if ($(window).scrollTop() + $(window).height() - e.pageY < 30) {
-                    // bottom
-                    $('html,body').animate({ scrollTop: $(window).scrollTop() + 50 }, 200);
-                } else if (e.pageY - $(window).scrollTop() < 30) {
-                    // top
-                    $('html,body').animate({ scrollTop: $(window).scrollTop() - 50 }, 200);
+
+            this.ondragstart = function (e) {
+                e.dataTransfer.setData('Text', $(this).attr('data-drag_id'));
+                e.dataTransfer.setData('draggable', true);
+                $('<div id="drop-marker" style="position: absolute; width: 100%;"></div>').insertBefore(this);
+            };
+            this.ondragenter = function (e) {
+                return false;
+            };
+            this.ondragleave = function (e) {
+                return false;
+            };
+            this.ondragover = function (e) {
+                var position = $(this).position(), height = $(this).height(), marker = $('#drop-marker');
+                marker.css('border-bottom', '5px dotted red');
+                if (e.pageY < $(this).offset().top + height / 2) {
+                    marker.css('top', position.top + 1 + 'px');
+                    $(this).attr('draghalf', 'top');
+                } else {
+                    marker.css('top', position.top + height + 21 + 'px');
+                    $(this).attr('draghalf', 'bottom');
                 }
-            }
-            return false;
-        }).bind('drop', function (e) {
-        	/* We move the field, into the same fieldset (simple reorder into the fieldset)
-        	 * or into an other fieldset (we set a new position in a new fieldset)
-        	 */
-            e.preventDefault();
-            var src = e.originalEvent.dataTransfer.getData('Text'), node = $('[data-drag_id=' + src + ']');
-            if ($(this).attr('data-drag_id') === src) {
-                return;
-            }
-            if ($(this).attr('draghalf') === 'top') {
-                node.insertBefore(this);
-            } else {
-                node.insertAfter(this);
-            }
-            var target_fieldset_id = $(this).parents('fieldset').first().find('legend').attr('data-fieldset_drag_id');
-            // position is the new position of the field, in the same fielsdet or in the new fieldset
-            var position = node.parent().children('[data-drag_id]').index(node);
-            reorder_callback.apply(node, [
-                position,
-                target_fieldset_id
-            ]);
-        }).bind('dragend', function (e) {
-            $('#drop-marker').remove();
+                // window autoscroll
+                if (!$('html,body').is(':animated')) {
+                    if ($(window).scrollTop() + $(window).height() - e.pageY < 30) {
+                        // bottom
+                        $('html,body').animate({ scrollTop: $(window).scrollTop() + 50 }, 200);
+                    } else if (e.pageY - $(window).scrollTop() < 30) {
+                        // top
+                        $('html,body').animate({ scrollTop: $(window).scrollTop() - 50 }, 200);
+                    }
+                }
+                return false;
+            };
+            this.ondrop = function (e) {
+            	/* We move the field, into the same fieldset (simple reorder into the fieldset)
+            	 * or into an other fieldset (we set a new position in a new fieldset)
+            	 */
+                e.preventDefault();
+                var src = e.dataTransfer.getData('Text'), node = $('[data-drag_id=' + src + ']');
+                if ($(this).attr('data-drag_id') === src) {
+                    return;
+                }
+                if ($(this).attr('draghalf') === 'top') {
+                    node.insertBefore(this);
+                } else {
+                    node.insertAfter(this);
+                }
+                var target_fieldset_id = $(this).parents('fieldset').first().find('legend').attr('data-fieldset_drag_id');
+                // position is the new position of the field, in the same fielsdet or in the new fieldset
+                var position = node.parent().children('[data-drag_id]').index(node);
+                reorder_callback.apply(node, [
+                    position,
+                    target_fieldset_id
+                ]);
+            };
+            this.ondragend = function (e) {
+                $('#drop-marker').remove();
+            };
         });
         // Make tab and legend elements droppable. we drop on legend when form tabbing is disabled
         $('#form fieldset legend').attr('droppable', 'true').each(function (i) {
@@ -90,50 +99,53 @@
         $('.formTabs .formTab').attr('droppable', 'true').each(function (i) {
             $(this).attr('data-fieldset_drag_id', i);
         });
-        $('.formTabs .formTab, #form fieldset legend').attr('droppable', 'true').bind('drop', function (e) {
-        	// apply change fieldset when we drop a field on a tab or a legend
-            e.preventDefault();
-            var src = e.originalEvent.dataTransfer.getData('Text'), node = $('[data-drag_id=' + src + ']');
-            var orig_fieldset = node.parents('fieldset');
-            var orig_fieldset_id = orig_fieldset.attr('id').split('-')[1];
-            var target_fieldset_id = $(this).attr('data-fieldset_drag_id');
-            if (orig_fieldset_id != target_fieldset_id) {
-                var target_fieldset = $('#fieldset-' + target_fieldset_id), tab_height = $(this).height(), tab_width = $(this).width(), tab_position = $(this).position();
-                node.animate({
-                    top: tab_position.top - node.position().top,
-                    left: tab_position.left - node.position().left,
-                    width: '50%',
-                    opacity: '0'
-                }, 1000, function () {
-                    node.appendTo(target_fieldset);
-                    node.css('left', '');
-                    node.css('top', '');
-                    node.css('width', '');
-                    node.css('opacity', '');
-                });
-                changefieldset_callback.apply(node, [target_fieldset_id]);
-            }
-            $(this).css('border', '');
-        }).bind('dragover', function (e) {
-        	// style when we drag over tab or legend
-            e.preventDefault();
-            var draggable = e.originalEvent.dataTransfer.getData('draggable');
-            if (draggable) {
-                $(this).css('border', '3px dotted red');
-                $('#drop-marker').hide();
-            }
-            return false;
-        }).bind('dragleave', function (e) {
-        	// remove style when we leave tab or legend
-            e.preventDefault();
-            $(this).css('border', '');
-            $('#drop-marker').show();
+        $('.formTabs .formTab, #form fieldset legend').attr('droppable', 'true').each(function(){
+            this.ondrop = function (e) {
+            	// apply change fieldset when we drop a field on a tab or a legend
+                e.preventDefault();
+                debugger;
+                var src = e.dataTransfer.getData('Text'), node = $('[data-drag_id=' + src + ']');
+                var orig_fieldset = node.parents('fieldset');
+                var orig_fieldset_id = orig_fieldset.attr('id').split('-')[1];
+                var target_fieldset_id = $(this).attr('data-fieldset_drag_id');
+                if (orig_fieldset_id != target_fieldset_id) {
+                    var target_fieldset = $('#fieldset-' + target_fieldset_id), tab_height = $(this).height(), tab_width = $(this).width(), tab_position = $(this).position();
+                    node.animate({
+                        top: tab_position.top - node.position().top,
+                        left: tab_position.left - node.position().left,
+                        width: '50%',
+                        opacity: '0'
+                    }, 1000, function () {
+                        node.appendTo(target_fieldset);
+                        node.css('left', '');
+                        node.css('top', '');
+                        node.css('width', '');
+                        node.css('opacity', '');
+                    });
+                    changefieldset_callback.apply(node, [target_fieldset_id]);
+                }
+                $(this).css('border', '');
+            };
+            this.ondragover = function (e) {
+            	// style when we drag over tab or legend
+                e.preventDefault();
+                var draggable = e.dataTransfer.getData('draggable');
+                if (draggable) {
+                    $(this).css('border', '3px dotted red');
+                    $('#drop-marker').hide();
+                }
+                return false;
+            };
+            this.ondragleave = function (e) {
+            	// remove style when we leave tab or legend
+                e.preventDefault();
+                $(this).css('border', '');
+                $('#drop-marker').show();
+            };
         });
         $('<span class="draghandle">&#x28FF;</span>').css('cursor', 'ns-resize').prependTo('.fieldPreview.orderable .fieldLabel');
     };
     $(function () {
-        var common_content_filter = '#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
-            baseURL = window.location.href.split('?')[0];
         // delete field
         $('a.schemaeditor-delete-field').click(function (e) {
             var trigger = $(this);
@@ -149,54 +161,24 @@
         });
         // reorder fields and change fieldsets
         $('.fieldPreview.orderable').plone_schemaeditor_html5_sortable(function (position, fieldset_index) {
-            var url = baseURL.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
+            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
             $.post(url, {
                 _authenticator: $('input[name="_authenticator"]').val(),
                 pos: position,
                 fieldset_index: fieldset_index
             });
         }, function (fieldset_index) {
-            var url = baseURL.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
+            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
             $.post(url, {
                 _authenticator: $('input[name="_authenticator"]').val(),
                 fieldset_index: fieldset_index
             });
         });
-        // field settings form
-        $('a.fieldSettings').prepOverlay({
-            subtype: 'ajax',
-            filter: common_content_filter,
-            closeselector: 'input[name="form.buttons.cancel"]',
-            formselector: '#edit-field-form.kssattr-formname-edit',
-            noform: function(el) {
-                var o = $(el), emsg = o.find('dl.portalMessage.error');
-                if (emsg.length) {
-                    o.children().replaceWith(emsg);
-                    return false;
-                } else {
-                    return 'reload';
-                }
-            }
-        });
-        // add new field to form
-        $('#add-field').prepOverlay({
-            subtype: 'ajax',
-            filter: common_content_filter,
-            formselector: 'form#add-field-form',
-            noform: 'reload'
-        });
-        // add new fieldset to form
-        $('#add-fieldset').prepOverlay({
-            subtype: 'ajax',
-            filter: common_content_filter,
-            formselector: 'form#add-fieldset-form',
-            noform: 'reload'
-        });
-        set_id_from_title = function () {
+        var set_id_from_title = function () {
             var id = $.plone_schemaeditor_normalize_string($(this).val());
             $('#form-widgets-__name__').val(id);
         };
         // set id from title
-        $(document).on('focusout', '#form-widgets-title, #form-widgets-label', set_id_from_title);
+        $('body').on('focusout', '#form-widgets-title, #form-widgets-label', set_id_from_title);
     });
 }(jQuery));

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -103,7 +103,6 @@
             this.ondrop = function (e) {
             	// apply change fieldset when we drop a field on a tab or a legend
                 e.preventDefault();
-                debugger;
                 var src = e.dataTransfer.getData('Text'), node = $('[data-drag_id=' + src + ']');
                 var orig_fieldset = node.parents('fieldset');
                 var orig_fieldset_id = orig_fieldset.attr('id').split('-')[1];
@@ -161,14 +160,14 @@
         });
         // reorder fields and change fieldsets
         $('.fieldPreview.orderable').plone_schemaeditor_html5_sortable(function (position, fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
+            var url = window.location.pathname.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
             $.post(url, {
                 _authenticator: $('input[name="_authenticator"]').val(),
                 pos: position,
                 fieldset_index: fieldset_index
             });
         }, function (fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
+            var url = window.location.pathname.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
             $.post(url, {
                 _authenticator: $('input[name="_authenticator"]').val(),
                 fieldset_index: fieldset_index

--- a/plone/schemaeditor/configure.zcml
+++ b/plone/schemaeditor/configure.zcml
@@ -5,6 +5,7 @@
     i18n_domain="plone.schemaeditor">
 
     <include package="plone.z3cform"/>
+    <include package="plone.protect" />
 
     <i18n:registerTranslations directory="locales"/>
 

--- a/plone/schemaeditor/testing.py
+++ b/plone/schemaeditor/testing.py
@@ -33,8 +33,6 @@ class PloneSchemaeditorRobotLayer(PloneSandboxLayer):
         """Set up Plone."""
         # Install into Plone site using portal_setup
         applyProfile(portal, 'plone.schemaeditor.tests:testing')
-        #applyProfile(portal, 'plone.app.z3cform:default')
-        #applyProfile(portal, 'plone.app.dexterity:default')
 
         # Login and create some test content
         setRoles(portal, TEST_USER_ID, ['Manager'])

--- a/plone/schemaeditor/tests/browser_testing.zcml
+++ b/plone/schemaeditor/tests/browser_testing.zcml
@@ -2,9 +2,14 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser">
 
+    <include package="Products.GenericSetup" file="meta.zcml" />
     <include package="Products.Five" file="meta.zcml" />
     <include package="Products.Five" />
     <include package="plone.schemaeditor"/>
+
+    <!-- dummy keyring -->
+    <utility component=".fixtures.DummyKeyManager"
+             provides="plone.keyring.interfaces.IKeyManager" />
 
     <!-- dummy schema editing context -->
     <browser:page

--- a/plone/schemaeditor/tests/choice.txt
+++ b/plone/schemaeditor/tests/choice.txt
@@ -14,8 +14,8 @@ schema editor.
     >>> user = app.acl_users.userFolderAddUser(
     ...     'root', 'secret', ['Manager'], [])
 
-    >>> from Testing.testbrowser import Browser
-    >>> browser = Browser()
+    >>> from Products.Five import testbrowser
+    >>> browser = testbrowser.Browser()
     >>> browser.handleErrors = False
     >>> browser.addHeader('Authorization', 'Basic root:secret')
 
@@ -207,7 +207,7 @@ Back to the edit form, vocabulary name is selected.
 
     >>> browser.open(portal_url + '/@@schemaeditor')
     >>> browser.getLink(url='categories').click()
-    >>> print browser.contents
-    <...
-    ... selected>plone.schemaeditor.test.Categories</option...
-    ...
+    >>> from lxml import html
+    >>> result = html.fromstring(browser.contents)
+    >>> opt = result.find('.//option[@value="plone.schemaeditor.test.Categories"]')
+    >>> assert opt.get('selected') is not None

--- a/plone/schemaeditor/tests/choice.txt
+++ b/plone/schemaeditor/tests/choice.txt
@@ -13,8 +13,9 @@ schema editor.
 
     >>> user = app.acl_users.userFolderAddUser(
     ...     'root', 'secret', ['Manager'], [])
-    >>> from Testing.testbrowser import Browser
-    >>> browser = Browser()
+
+    >>> from Products.Five import testbrowser
+    >>> browser = testbrowser.Browser()
     >>> browser.handleErrors = False
     >>> browser.addHeader('Authorization', 'Basic root:secret')
 
@@ -205,5 +206,5 @@ Back to the edit form, vocabulary name is selected.
     >>> browser.getLink(url='categories').click()
     >>> print browser.contents
     <...
-    ... selected="selected">plone.schemaeditor.test.Categories</option...
+    ... selected>plone.schemaeditor.test.Categories</option...
     ...

--- a/plone/schemaeditor/tests/choice.txt
+++ b/plone/schemaeditor/tests/choice.txt
@@ -14,8 +14,8 @@ schema editor.
     >>> user = app.acl_users.userFolderAddUser(
     ...     'root', 'secret', ['Manager'], [])
 
-    >>> from Products.Five import testbrowser
-    >>> browser = testbrowser.Browser()
+    >>> from Testing.testbrowser import Browser
+    >>> browser = Browser()
     >>> browser.handleErrors = False
     >>> browser.addHeader('Authorization', 'Basic root:secret')
 
@@ -102,11 +102,12 @@ We can select a vocabulary factory instead of values.
     [event: ObjectModifiedEvent on Choice]
     [event: SchemaModifiedEvent on DummySchemaContext]
     >>> browser.open(portal_url + '/@@contexteditor')
-    >>> print browser.contents
-    <...
-    <option id="form-widgets-country-0" value="fr">France...
-    <option id="form-widgets-country-1" value="uk">United Kingdom...
-    <option id="form-widgets-country-2" value="es">Spain...
+    >>> '<option id="form-widgets-country-0" value="fr">France' in browser.contents
+    True
+    >>> '<option id="form-widgets-country-1" value="uk">United Kingdom' in browser.contents
+    True
+    >>> '<option id="form-widgets-country-2" value="es">Spain' in browser.contents
+    True
 
 We can't set a vocabulary name AND values.
 
@@ -194,11 +195,13 @@ We can select a vocabulary factory instead of values.
     [event: ObjectModifiedEvent on Set]
     [event: SchemaModifiedEvent on DummySchemaContext]
     >>> browser.open(portal_url + '/@@contexteditor')
-    >>> print browser.contents
-    <...
-    <option id="form-widgets-categories-0" value="php">PHP...
-    <option id="form-widgets-categories-1" value="c">C...
-    <option id="form-widgets-categories-2" value="ruby">Ruby...
+    >>> '<option id="form-widgets-categories-0" value="php">PHP' in browser.contents
+    True
+    >>> '<option id="form-widgets-categories-1" value="c">C' in browser.contents
+    True
+    >>> '<option id="form-widgets-categories-2" value="ruby">Ruby' in browser.contents
+    True
+
 
 Back to the edit form, vocabulary name is selected.
 

--- a/plone/schemaeditor/tests/fixtures.py
+++ b/plone/schemaeditor/tests/fixtures.py
@@ -71,12 +71,26 @@ class CategoriesVocabulary(BaseVocabulary):
                    ('ruby', u'Ruby')]
 
 
-class DummyKeyring(object):
+try:
+    # detect plone.protect 3.0, easier to mock
+    from plone.protect.authenticator import _getKeyring   # noqa
 
-    def random(self):
-        return 'a'
+    class DummyKeyring(object):
 
+        def random(self):
+            return 'a'
 
-DummyKeyManager = {
-    u'_forms': DummyKeyring(),
-}
+    DummyKeyManager = {
+        u'_forms': DummyKeyring(),
+    }
+except ImportError:
+    # plone.protect < 3.0
+
+    class _DummyKeyManager(object):
+        """Mock aims to be plone.protect 2.0 and 3.0 compatible"""
+
+        def secret(self, ring=u'_forms'):
+            return 'a'
+
+    DummyKeyManager = _DummyKeyManager()
+

--- a/plone/schemaeditor/tests/fixtures.py
+++ b/plone/schemaeditor/tests/fixtures.py
@@ -69,3 +69,14 @@ class CategoriesVocabulary(BaseVocabulary):
     values_list = [('php', u'PHP'),
                    ('c', u'C'),
                    ('ruby', u'Ruby')]
+
+
+class DummyKeyring(object):
+
+    def random(self):
+        return 'a'
+
+
+DummyKeyManager = {
+    u'_forms': DummyKeyring(),
+}

--- a/plone/schemaeditor/tests/robot_testing.zcml
+++ b/plone/schemaeditor/tests/robot_testing.zcml
@@ -6,7 +6,6 @@
 
     <include package="plone.schemaeditor"/>
 
-	<include package="Products.GenericSetup" file="meta.zcml" />
     <gs:registerProfile
         name="testing"
         title="plone.schemaeditor tests"

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(name='plone.schemaeditor',
           'plone.app.dexterity',
           'plone.app.testing',
           'plone.app.robotframework',
+          'lxml',
       ]},
       )


### PR DESCRIPTION
These fixes allow use of plone.schemaeditor on Plone 4 sites using either/both plone.protect 3.x and/or plone.app.widgets 1.x (with mockup 2).

These fixes are IMHO important enough to justify a 1.3.12 release.