### PR TITLE
Fix accidental removal of overlay handlers (fixes regression in 1.4)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Re-add overlay registration for Plone 4 accidentally removed in 1.4.
+  [seanupton]
 
 
 1.4 (2016-10-03)

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -177,6 +177,36 @@
             var id = $.plone_schemaeditor_normalize_string($(this).val());
             $('#form-widgets-__name__').val(id);
         };
+        // field settings form
+                   $('a.fieldSettings').prepOverlay({
+            subtype: 'ajax',
+            filter: common_content_filter,
+            closeselector: 'input[name="form.buttons.cancel"]',
+            formselector: '#edit-field-form.kssattr-formname-edit',
+            noform: function(el) {
+                var o = $(el), emsg = o.find('dl.portalMessage.error');
+                if (emsg.length) {
+                    o.children().replaceWith(emsg);
+                    return false;
+                } else {
+                    return 'reload';
+                }
+            }
+        });
+        // add new field to form
+                   $('#add-field').prepOverlay({
+            subtype: 'ajax',
+            filter: common_content_filter,
+            formselector: 'form#add-field-form',
+            noform: 'reload'
+        });
+        // add new fieldset to form
+                   $('#add-fieldset').prepOverlay({
+            subtype: 'ajax',
+            filter: common_content_filter,
+            formselector: 'form#add-fieldset-form',
+            noform: 'reload'
+        });
         // set id from title
         $('body').on('focusout', '#form-widgets-title, #form-widgets-label', set_id_from_title);
     });


### PR DESCRIPTION
I accidentally removed prepOverlay calls needed in Plone 4 schema editor in my backport of the JavaScript from Plone 5's schema editor (master) backport in my commit 8774cddaf1079eea3cda805c62f5cbdf7e0ff68e

This PR fixes that accidental removal.