### PR TITLE
Fix URL for reordering fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix POST AJAX-URL for reordering fields
+  [tomgross]
 
 
 2.0.13 (2017-01-01)

--- a/plone/schemaeditor/browser/field/edit.py
+++ b/plone/schemaeditor/browser/field/edit.py
@@ -16,7 +16,7 @@ from z3c.form.datamanager import AttributeField
 from z3c.form.interfaces import IDataManager
 from zope import schema
 from zope.cachedescriptors.property import Lazy as lazy_property
-from zope.component import adapts
+from zope.component import adapter
 from zope.component import getAdapters
 from zope.event import notify
 from zope.i18nmessageid import Message
@@ -41,8 +41,8 @@ class IFieldTitle(Interface):
 
 
 @implementer(IFieldTitle)
+@adapter(IField)
 class FieldTitleAdapter(object):
-    adapts(IField)
 
     def __init__(self, field):
         self.field = field
@@ -80,8 +80,8 @@ class FieldProxy(object):
 
 
 @implementer(IDataManager)
+@adapter(IFieldProxy, IField)
 class FieldDataManager(AttributeField):
-    adapts(IFieldProxy, IField)
 
     def get(self):
         value = super(FieldDataManager, self).get()

--- a/plone/schemaeditor/browser/schema/add_field.py
+++ b/plone/schemaeditor/browser/schema/add_field.py
@@ -90,7 +90,7 @@ class FieldAddForm(AutoExtensibleForm, form.AddForm):
         notify(ObjectAddedEvent(field, context.schema))
         notify(FieldAddedEvent(context, field))
         IStatusMessage(self.request).addStatusMessage(
-            _(u"Field added successfully."), type='info')
+            _(u'Field added successfully.'), type='info')
 
     def nextURL(self):
         return '@@add-field'

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -161,14 +161,24 @@
         });
         // reorder fields and change fieldsets
         $('.fieldPreview.orderable').plone_schemaeditor_html5_sortable(function (position, fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@order';
+            var url = [location.protocol, '//',
+                       location.host,
+                       location.pathname.replace('/@@fields', ''),
+                       '/',
+                       this.attr('data-field_id'),
+                       '/@@order'].join('');
             $.post(url, {
                 _authenticator: $('input[name="_authenticator"]').val(),
                 pos: position,
                 fieldset_index: fieldset_index
             });
         }, function (fieldset_index) {
-            var url = window.location.href.replace('/@@fields', '') + '/' + this.attr('data-field_id') + '/@@changefieldset';
+            var url = [location.protocol, '//',
+                       location.host,
+                       location.pathname.replace('/@@fields', ''),
+                       '/',
+                       this.attr('data-field_id'),
+                       '/@@changefieldset'].join('');
             $.post(url, {
                 _authenticator: $('input[name="_authenticator"]').val(),
                 fieldset_index: fieldset_index

--- a/plone/schemaeditor/fields.py
+++ b/plone/schemaeditor/fields.py
@@ -7,7 +7,6 @@ from z3c.form import validator
 from zope import component
 from zope import interface
 from zope import schema
-from zope.component import adapter
 from zope.component import getUtilitiesFor
 from zope.globalrequest import getRequest
 from zope.i18n import translate
@@ -110,8 +109,8 @@ ChoiceFactory = FieldFactory(
 
 
 @interface.implementer(se_schema.ITextLineChoice)
+@component.adapter(schema_ifaces.IChoice)
 class TextLineChoiceField(object):
-    component.adapts(schema_ifaces.IChoice)
 
     def __init__(self, field):
         self.__dict__['field'] = field
@@ -156,13 +155,13 @@ class TextLineChoiceField(object):
         return delattr(self.field, name)
 
 
+@component.adapter(interface.Interface, interface.Interface,
+                   interfaces.IFieldEditForm,
+                   se_schema.ITextLinesField, interface.Interface)
 class VocabularyValuesValidator(validator.SimpleFieldValidator):
 
     """Ensure duplicate vocabulary terms are not submitted
     """
-    component.adapts(interface.Interface, interface.Interface,
-                     interfaces.IFieldEditForm,
-                     se_schema.ITextLinesField, interface.Interface)
 
     def validate(self, values):
         if values is None:
@@ -217,6 +216,7 @@ class VocabularyNameValidator(validator.SimpleFieldValidator):
 
         return super(VocabularyNameValidator, self).validate(values)
 
+
 validator.WidgetValidatorDiscriminators(
     VocabularyNameValidator,
     field=se_schema.ITextLineChoice['vocabularyName'])
@@ -235,8 +235,8 @@ MultiChoiceFactory = FieldFactory(
 
 
 @interface.implementer_only(se_schema.ITextLineChoice)
+@component.adapter(schema_ifaces.ISet)
 class TextLineMultiChoiceField(TextLineChoiceField):
-    component.adapts(schema_ifaces.ISet)
 
     def __init__(self, field):
         self.__dict__['field'] = field
@@ -272,7 +272,7 @@ class TextLineMultiChoiceField(TextLineChoiceField):
 
 
 # make Bool fields use the radio widget by default
-@adapter(schema_ifaces.IBool, IObjectAddedEvent)
+@component.adapter(schema_ifaces.IBool, IObjectAddedEvent)
 def setBoolWidget(field, event):
     schema = field.interface
     widgets = schema.queryTaggedValue('plone.autoform.widgets', {})

--- a/plone/schemaeditor/interfaces.py
+++ b/plone/schemaeditor/interfaces.py
@@ -21,13 +21,11 @@ import re
 
 
 class ISchemaView(IBrowserPage):
-
     """ A publishable view of a zope 3 schema
     """
 
 
 class ISchemaContext(IItem):
-
     """ A publishable wrapper of a zope 3 schema
     """
 
@@ -63,7 +61,6 @@ class ISchemaModifiedEvent(IObjectEvent):
 
 
 class IFieldContext(IItem):
-
     """ A publishable wrapper of a zope 3 schema field
     """
 
@@ -73,7 +70,6 @@ class IFieldContext(IItem):
 
 
 class IFieldEditorExtender(IInterface):
-
     """ An additional schema for use when editing a field."""
 
 
@@ -130,6 +126,7 @@ class IFieldEditForm(IEditForm):
 class IFieldEditFormSchema(Interface):
     """ The schema describing the form fields for a field.
     """
+
 
 RESERVED_NAMES = (
     'subject',

--- a/plone/schemaeditor/tests/fixtures.py
+++ b/plone/schemaeditor/tests/fixtures.py
@@ -32,7 +32,7 @@ def log_event(object, event):
     print('[event: {0} on {1}]'.format(
         event.__class__.__name__,
         object.__class__.__name__,
-    ))
+    ))       # noqa
 
 
 class EditForm(EditForm):
@@ -43,6 +43,7 @@ class EditForm(EditForm):
     def update(self):
         self.fields = field.Fields(IDummySchema)
         super(EditForm, self).update()
+
 
 EditView = layout.wrap_form(EditForm)
 

--- a/plone/schemaeditor/tests/tests.py
+++ b/plone/schemaeditor/tests/tests.py
@@ -74,8 +74,7 @@ class RenderWidget(object):
         return self.widget.render()
 
 
-path = lambda p: os.path.join(os.path.dirname(__file__), p)
 layout_factory = ZopeTwoFormTemplateFactory(
-    path('layout.pt'),
+    os.path.join(os.path.dirname(__file__), 'layout.pt'),
     form=IFormWrapper, request=ITestLayer,
 )

--- a/plone/schemaeditor/utils.py
+++ b/plone/schemaeditor/utils.py
@@ -2,7 +2,7 @@
 from plone.schemaeditor.interfaces import IEditableSchema
 from plone.schemaeditor.interfaces import ISchemaModifiedEvent
 from plone.supermodel.interfaces import FIELDSETS_KEY
-from zope.component import adapts
+from zope.component import adapter
 from zope.component.interfaces import ObjectEvent
 from zope.interface import implementer
 from zope.interface.interfaces import IInterface
@@ -45,13 +45,13 @@ def get_field_fieldset(schema, field_name):
 
 
 @implementer(IEditableSchema)
+@adapter(IInterface)
 class EditableSchema(object):
 
     """ Zope 3 schema adapter to allow addition/removal of schema fields
 
         XXX this needs to be made threadsafe
     """
-    adapts(IInterface)
 
     def __init__(self, schema):
         self.schema = schema


### PR DESCRIPTION
This PR fixes the URL for the reordering and changing fieldsets. It removes the query_string from the base part of the URL.

Before:
http://localhost:8080/Plone/a-form/fields/topic/?authenticator=075c08f07c45ce137c77f6be5c422c2041587407/@@order 

Now:
http://localhost:8080/Plone/a-form/fields/topic/@@order 
(the authenticatior is in the POST)

Test with collective.easyform.