### PR TITLE
Manage simple "vocabularies" in the values field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ New features:
 
 - Add fields in field editing UI to the current selected fieldset.
   [thet]
+- Allow specifying a vocabulary in the form of *key|label* in (multi)choice fields
+  [tomgross]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New features:
 - Allow specifying a vocabulary in the form of *key|label* in (multi)choice fields
   [tomgross]
 
+- Removed very old import conditions
+  [tomgross]
+
 Bug fixes:
 
 - Fix Schemaeditor fields editing UI to be able to move fields into another fieldset.

--- a/plone/schemaeditor/fields.py
+++ b/plone/schemaeditor/fields.py
@@ -120,7 +120,7 @@ class TextLineChoiceField(object):
             values = []
             for term in (self.field.vocabulary or []):
                 if term.value != term.title:
-                    values.append('%s|%s' % (term.value, term.title))
+                    values.append('{0:s}|{1:s}'.format(term.value, term.title))
                 else:
                     values.append(term.value)
             return values
@@ -260,7 +260,7 @@ class TextLineMultiChoiceField(TextLineChoiceField):
             values = []
             for term in (self.field.vocabulary or []):
                 if term.value != term.title:
-                    values.append('%s|%s' % (term.value, term.title))
+                    values.append('{0:s}|{1:s}'.format(term.value, term.title))
                 else:
                     values.append(term.value)
             return values

--- a/plone/schemaeditor/fields.py
+++ b/plone/schemaeditor/fields.py
@@ -117,17 +117,30 @@ class TextLineChoiceField(object):
 
     def __getattr__(self, name):
         if name == 'values':
-            return [term.value for term in (self.field.vocabulary or [])]
+            values = []
+            for term in (self.field.vocabulary or []):
+                if term.value != term.title:
+                    values.append('%s|%s' % (term.value, term.title))
+                else:
+                    values.append(term.value)
+            return values
+
 
         return getattr(self.field, name)
 
     def _constructVocabulary(self, value):
         terms = []
         if value:
-            for value in value:
+            for item in value:
+                if item and '|' in item:
+                    voc_value, voc_title = item.split('|', 1)
+                else:
+                    voc_value = item
+                    voc_title = item
+
                 term = vocabulary.SimpleTerm(
-                    token=value.encode('unicode_escape'),
-                    value=value, title=value)
+                    token=voc_value.encode('unicode_escape'),
+                    value=voc_value, title=voc_title)
                 terms.append(term)
 
         return vocabulary.SimpleVocabulary(terms)
@@ -244,8 +257,13 @@ class TextLineMultiChoiceField(TextLineChoiceField):
     def __getattr__(self, name):
         field = self.field
         if name == 'values':
-            return [term.value
-                    for term in (field.value_type.vocabulary or [])]
+            values = []
+            for term in (self.field.vocabulary or []):
+                if term.value != term.title:
+                    values.append('%s|%s' % (term.value, term.title))
+                else:
+                    values.append(term.value)
+            return values
         elif name == 'vocabularyName':
             return getattr(field.value_type, name, None) or \
                    getattr(field, name)

--- a/plone/schemaeditor/tests/test_fields.py
+++ b/plone/schemaeditor/tests/test_fields.py
@@ -3,6 +3,7 @@ from plone.app.testing import PLONE_FIXTURE
 from plone.schemaeditor.fields import TextLineChoiceField
 from plone.schemaeditor.fields import TextLineMultiChoiceField
 from zope.schema.interfaces import IVocabularyTokenized
+
 import unittest
 
 
@@ -13,6 +14,7 @@ class DummyField(object):
         self.value_type = self
 
     vocabulary = None
+
 
 class VocabularyTestCase(unittest.TestCase):
 
@@ -42,4 +44,3 @@ class VocabularyTestCase(unittest.TestCase):
             [(u'New York', u'New York', u'New York'),
              (u'city1', u'city1', u'Zürich')]
             )
-

--- a/plone/schemaeditor/tests/test_fields.py
+++ b/plone/schemaeditor/tests/test_fields.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from plone.app.testing import PLONE_FIXTURE
+from plone.schemaeditor.fields import TextLineChoiceField
+from plone.schemaeditor.fields import TextLineMultiChoiceField
+from zope.schema.interfaces import IVocabularyTokenized
+import unittest
+
+
+class DummyField(object):
+    """ Dummy field """
+
+    def __init__(self):
+        self.value_type = self
+
+    vocabulary = None
+
+class VocabularyTestCase(unittest.TestCase):
+
+    layer = PLONE_FIXTURE
+
+    def assertVocabulary(self, voc, values):
+        self.assertTrue(IVocabularyTokenized.providedBy(voc))
+        self.assertEqual(
+            [(term.value, term.token, term.title) for term in voc],
+            values
+        )
+
+    def test_singlechoice_voc(self):
+        field = TextLineChoiceField(DummyField())
+        field.values = [u'New York', u'city2|München']
+        self.assertVocabulary(
+            field.vocabulary,
+            [(u'New York', u'New York', u'New York'),
+             (u'city2', u'city2', u'München')]
+          )
+
+    def test_multichoice_voc(self):
+        field = TextLineMultiChoiceField(DummyField())
+        field.values = [u'New York', u'city1|Zürich']
+        self.assertVocabulary(
+            field.vocabulary,
+            [(u'New York', u'New York', u'New York'),
+             (u'city1', u'city1', u'Zürich')]
+            )
+

--- a/plone/schemaeditor/tests/tests.py
+++ b/plone/schemaeditor/tests/tests.py
@@ -5,6 +5,7 @@ from Testing import ZopeTestCase as ztc
 from zope.interface import classImplements
 from zope.interface import implementedBy
 from zope.interface import Interface
+from Zope2.App import zcml
 from ZPublisher.BaseRequest import BaseRequest
 
 import doctest
@@ -12,11 +13,6 @@ import os
 import plone.schemaeditor
 import unittest
 
-# BBB for Zope 2.12
-try:
-    from Zope2.App import zcml
-except ImportError:
-    from Products.Five import zcml
 
 optionflags = (doctest.ELLIPSIS |
                doctest.NORMALIZE_WHITESPACE |
@@ -24,18 +20,8 @@ optionflags = (doctest.ELLIPSIS |
 
 
 def setUp(self):
-    try:
-        from Zope2.App.schema import configure_vocabulary_registry
-    except ImportError:
-        try:
-            from zope.schema.vocabulary import setVocabularyRegistry
-            from Products.Five.schema import Zope2VocabularyRegistry
-        except ImportError:
-            pass
-        else:
-            setVocabularyRegistry(Zope2VocabularyRegistry())
-    else:
-        configure_vocabulary_registry()
+    from Zope2.App.schema import configure_vocabulary_registry
+    configure_vocabulary_registry()
 
     zcml.load_config('browser_testing.zcml', plone.schemaeditor.tests)
 


### PR DESCRIPTION
Allow specifying a vocabulary in the form of *key|label* in (multi)choice fields as seen at PFG.