### PR TITLE
fix schemaeditor fields editing UI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add fields in field editing UI to the current selected fieldset.
+  [thet]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,9 @@ Bug fixes:
 - JavaScript formating according to style guides.
   [thet]
 
-- Cleanup: Remove Plone 4 related form tabbing CSS selectors from fields editing UI JavaScript.
+- Cleanup:
+  - Remove Plone 4 related form tabbing CSS selectors from fields editing UI JavaScript.
+  - Better code reuse.
   [thet]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix Schemaeditor fields editing UI to be able to move fields into another fieldset.
+  Fixes: #30.
+  [thet]
 
 - JavaScript formating according to style guides.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Bug fixes:
 
 - *add item here*
 
+- JavaScript formating according to style guides.
+  [thet]
+
 
 2.0.15 (2017-02-12)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Bug fixes:
 - JavaScript formating according to style guides.
   [thet]
 
+- Cleanup: Remove Plone 4 related form tabbing CSS selectors from fields editing UI JavaScript.
+  [thet]
+
 
 2.0.15 (2017-02-12)
 -------------------

--- a/plone/schemaeditor/browser/field/fieldset.py
+++ b/plone/schemaeditor/browser/field/fieldset.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from plone.schemaeditor.interfaces import IEditableSchema
+from plone.schemaeditor.utils import new_field_position
+from plone.schemaeditor.utils import get_fieldset_from_index
 from plone.schemaeditor.utils import SchemaModifiedEvent
-from plone.schemaeditor.utils import sortedFields
-from plone.supermodel.interfaces import FIELDSETS_KEY
 from Products.Five import BrowserView
 from zope.container.contained import notifyContainerModified
 from zope.event import notify
@@ -10,53 +10,17 @@ from zope.event import notify
 
 class ChangeFieldsetView(BrowserView):
 
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
-        self.field = context.field
-        self.schema = context.field.interface
-
     def change(self, fieldset_index):
         """ AJAX method to change the fieldset of a field
         """
-        fieldset_index = int(fieldset_index)
-        fieldsets = self.schema.queryTaggedValue(FIELDSETS_KEY, [])
-        field_name = self.field.__name__
+        schema = self.context.field.interface
+        field_name = self.context.field.__name__
+        fieldset = get_fieldset_from_index(schema, fieldset_index)
+        position = new_field_position(schema, fieldset)
 
-        # get current fieldset
-        fieldset_fields = []
-        for fieldset in fieldsets:
-            fieldset_fields.extend(fieldset.fields)
+        editable_schema = IEditableSchema(schema)
+        editable_schema.changeFieldFieldset(field_name, fieldset)
+        editable_schema.moveField(field_name, position)
 
-        # get future fieldset
-        fieldset_index -= 1
-
-        if fieldset_index >= 0:
-            # the field has not been moved into default
-            next_fieldset = fieldsets[fieldset_index]
-        else:
-            next_fieldset = None
-
-        # computing new Position, which is the last position of the new
-        # fieldset
-        ordered_field_ids = [info[0] for info in sortedFields(self.schema)]
-        if next_fieldset is None:
-            # if this is the default,
-            new_position = ordered_field_ids.index(fieldset_fields[0])
-        else:
-            # first we get the first of the fieldsets after the new one
-            new_position = None
-            for fieldset in fieldsets[fieldsets.index(next_fieldset) + 1:]:
-                if len(fieldset.fields) > 0:
-                    new_position = ordered_field_ids.index(
-                        fieldset.fields[0]) - 1
-                    break
-            else:
-                new_position = len(ordered_field_ids) - 1
-
-        schema = IEditableSchema(self.schema)
-        schema.changeFieldFieldset(field_name, next_fieldset)
-        schema.moveField(field_name, new_position)
-
-        notifyContainerModified(self.schema)
+        notifyContainerModified(schema)
         notify(SchemaModifiedEvent(self.__parent__.__parent__))

--- a/plone/schemaeditor/browser/field/fieldset.py
+++ b/plone/schemaeditor/browser/field/fieldset.py
@@ -16,7 +16,7 @@ class ChangeFieldsetView(BrowserView):
         schema = self.context.field.interface
         field_name = self.context.field.__name__
         fieldset = get_fieldset_from_index(schema, fieldset_index)
-        position = new_field_position(schema, fieldset)
+        position = new_field_position(schema, fieldset_index)
 
         editable_schema = IEditableSchema(schema)
         editable_schema.changeFieldFieldset(field_name, fieldset)

--- a/plone/schemaeditor/browser/schema/add_field.py
+++ b/plone/schemaeditor/browser/schema/add_field.py
@@ -3,13 +3,16 @@ from plone.autoform.form import AutoExtensibleForm
 from plone.schemaeditor import _
 from plone.schemaeditor import interfaces
 from plone.schemaeditor.utils import FieldAddedEvent
-from plone.schemaeditor.utils import new_field_position
+from plone.schemaeditor.utils import get_fieldset_from_index
 from plone.schemaeditor.utils import IEditableSchema
+from plone.schemaeditor.utils import new_field_position
 from plone.z3cform.layout import wrap_form
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form import field
 from z3c.form import form
+from z3c.form.browser.text import TextWidget
+from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import WidgetActionExecutionError
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getAdapters
@@ -63,9 +66,10 @@ class FieldAddForm(AutoExtensibleForm, form.AddForm):
 
     def add(self, new_field):
         schema = self.context.schema
-        position = new_field_position(schema)
-        editable_schema = IEditableSchema(schema)
+        fieldset_id = int(self.request.form.get('fieldset_id', 0))
+        position = new_field_position(schema, fieldset_id)
 
+        editable_schema = IEditableSchema(schema)
         try:
             editable_schema.addField(new_field)
         except ValueError:
@@ -75,12 +79,29 @@ class FieldAddForm(AutoExtensibleForm, form.AddForm):
                     u'Please select a field name that is not already used.'
                 )
             )
-
+        if fieldset_id:
+            fieldset = get_fieldset_from_index(schema, fieldset_id)
+            editable_schema.changeFieldFieldset(new_field.__name__, fieldset)
         editable_schema.moveField(new_field.__name__, position)
+
         notify(ObjectAddedEvent(new_field, schema))
         notify(FieldAddedEvent(self.context, new_field))
         IStatusMessage(self.request).addStatusMessage(
             _(u'Field added successfully.'), type='info')
+
+    def updateWidgets(self):
+        super(FieldAddForm, self).updateWidgets()
+        fieldset_id = int(self.request.form.get('fieldset_id', 0))
+        if fieldset_id:
+            # add fieldset_id from GET parameter as hidden field, so that
+            # ``add`` method at the end of the form lifecycle can read it.
+            fieldset_id_widget = TextWidget(self.request)
+            fieldset_id_widget.name = 'fieldset_id'
+            fieldset_id_widget.value = fieldset_id
+            fieldset_id_widget.mode = HIDDEN_MODE
+            # Uhm. z3c.form widgets doesn't have an API for extending a
+            # schema-generated form. Using internal ``_data_values``...
+            self.widgets._data_values.append(fieldset_id_widget)
 
     def nextURL(self):
         return '@@add-field'

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -1,6 +1,9 @@
 /*globals require */
 require(['jquery'], function($) {
     'use strict';
+
+    var droppable_initialized = false;
+
     $.plone_schemaeditor_normalize_string = function(s) {
         s = s.toLowerCase();
         var rules = {
@@ -36,6 +39,10 @@ require(['jquery'], function($) {
                 $(this).attr('data-drag_id', i);
 
                 this.ondragstart = function(e) {
+
+                    // initialize droppables on drag start - on document ready the tabs may not be initialized
+                    initialize_droppable(changefieldset_callback);
+
                     e.dataTransfer.setData('Text', $(this).attr('data-drag_id'));
                     e.dataTransfer.setData('draggable', true);
                     $(
@@ -106,20 +113,36 @@ require(['jquery'], function($) {
                     $('#drop-marker').remove();
                 };
             });
+
+        $('<span class="draghandle">&#x28FF;</span>')
+            .css('cursor', 'ns-resize')
+            .prependTo('.fieldPreview.orderable .fieldLabel');
+    };
+
+    var initialize_droppable = function (changefieldset_callback) {
+
+        if (droppable_initialized) {
+            // Don't do expensive double-initialization, when it's not necessary.
+            return;
+        }
+
         // Make tab and legend elements droppable. we drop on legend when form tabbing is disabled
+        $('#form .autotoc-nav > a').attr('droppable', 'true').each(function(i) {
+            // Plone 5 / mockup
+            $(this).attr('data-fieldset_drag_id', i);
+        });
         $('#form fieldset legend').attr('droppable', 'true').each(function(i) {
             $(this).attr('data-fieldset_drag_id', i);
         });
         $('.formTabs .formTab').attr('droppable', 'true').each(function(i) {
             $(this).attr('data-fieldset_drag_id', i);
         });
-        $('.formTabs .formTab, #form fieldset legend')
+        $('#form .autotoc-nav > a, .formTabs .formTab, #form fieldset legend')
             .attr('droppable', 'true')
             .each(function() {
                 this.ondrop = function(e) {
                     // apply change fieldset when we drop a field on a tab or a legend
                     e.preventDefault();
-                    debugger;
                     var src = e.dataTransfer.getData('Text'),
                         node = $('[data-drag_id=' + src + ']');
                     var orig_fieldset = node.parents('fieldset');
@@ -167,11 +190,11 @@ require(['jquery'], function($) {
                     $('#drop-marker').show();
                 };
             });
-        $('<span class="draghandle">&#x28FF;</span>')
-            .css('cursor', 'ns-resize')
-            .prependTo('.fieldPreview.orderable .fieldLabel');
+
+        droppable_initialized = true;
     };
-    $(function() {
+
+    $(document).ready(function() {
         // delete field
         $('a.schemaeditor-delete-field').click(function(e) {
             var trigger = $(this);

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -1,194 +1,238 @@
-/*jslint white: true, onevar: true, undef: true, newcap: true, nomen: true,
-  plusplus: true, bitwise: true, regexp: false, indent: 4 */
-/*globals jQuery, confirm */
-(function ($) {
+/*globals require */
+require(['jquery'], function($) {
     'use strict';
-
-    $.plone_schemaeditor_normalize_string = function (s) {
+    $.plone_schemaeditor_normalize_string = function(s) {
         s = s.toLowerCase();
         var rules = {
-                'a': /[àáâãäå]/g,
-                'ae': /[æ]/g,
-                'c': /[ç]/g,
-                'e': /[èéêë]/g,
-                'i': /[ìíîï]/g,
-                'n': /[ñ]/g,
-                'o': /[òóôõö]/g,
-                'oe': /[œ]/g,
-                'u': /[ùúûü]/g,
-                'y': /[ýÿ]/g,
-                'th': /[ðþ]/g,
-                'ss': /[ß]/g,
-                '_': /[\s\\]+/g
-            };
+            a: /[àáâãäå]/g,
+            ae: /[æ]/g,
+            c: /[ç]/g,
+            e: /[èéêë]/g,
+            i: /[ìíîï]/g,
+            n: /[ñ]/g,
+            o: /[òóôõö]/g,
+            oe: /[œ]/g,
+            u: /[ùúûü]/g,
+            y: /[ýÿ]/g,
+            th: /[ðþ]/g,
+            ss: /[ß]/g,
+            _: /[\s\\]+/g
+        };
         for (var r in rules)
             s = s.replace(rules[r], r);
         return s.replace(/[^a-z0-9_]/g, '_');
     };
-    $.fn.plone_schemaeditor_html5_sortable = function (reorder_callback, changefieldset_callback) {
+    $.fn.plone_schemaeditor_html5_sortable = function(
+        reorder_callback,
+        changefieldset_callback
+    ) {
         /* Takes two callbacks as arguments
          * reorder_callback : the callback when we move a field relatively to other fields
          * changefieldset_callback : the callback when we move a field to a legend or a tab
          */
-        this.attr('draggable', 'true').css('-webkit-user-drag', 'element').each(function (i) {
-            $(this).attr('data-drag_id', i);
+        this.attr('draggable', 'true')
+            .css('-webkit-user-drag', 'element')
+            .each(function(i) {
+                $(this).attr('data-drag_id', i);
 
-            this.ondragstart = function (e) {
-                e.dataTransfer.setData('Text', $(this).attr('data-drag_id'));
-                e.dataTransfer.setData('draggable', true);
-                $('<div id="drop-marker" style="position: absolute; width: 100%;"></div>').insertBefore(this);
-            };
-            this.ondragenter = function (e) {
-                return false;
-            };
-            this.ondragleave = function (e) {
-                return false;
-            };
-            this.ondragover = function (e) {
-                var position = $(this).position(), height = $(this).height(), marker = $('#drop-marker');
-                marker.css('border-bottom', '5px dotted red');
-                if (e.pageY < $(this).offset().top + height / 2) {
-                    marker.css('top', position.top + 1 + 'px');
-                    $(this).attr('draghalf', 'top');
-                } else {
-                    marker.css('top', position.top + height + 21 + 'px');
-                    $(this).attr('draghalf', 'bottom');
-                }
-                // window autoscroll
-                if (!$('html,body').is(':animated')) {
-                    if ($(window).scrollTop() + $(window).height() - e.pageY < 30) {
-                        // bottom
-                        $('html,body').animate({ scrollTop: $(window).scrollTop() + 50 }, 200);
-                    } else if (e.pageY - $(window).scrollTop() < 30) {
-                        // top
-                        $('html,body').animate({ scrollTop: $(window).scrollTop() - 50 }, 200);
+                this.ondragstart = function(e) {
+                    e.dataTransfer.setData('Text', $(this).attr('data-drag_id'));
+                    e.dataTransfer.setData('draggable', true);
+                    $(
+                        '<div id="drop-marker" style="position: absolute; width: 100%;"></div>'
+                    ).insertBefore(this);
+                };
+                this.ondragenter = function(e) {
+                    return false;
+                };
+                this.ondragleave = function(e) {
+                    return false;
+                };
+                this.ondragover = function(e) {
+                    var position = $(this).position(),
+                        height = $(this).height(),
+                        marker = $('#drop-marker');
+                    marker.css('border-bottom', '5px dotted red');
+                    if (e.pageY < $(this).offset().top + height / 2) {
+                        marker.css('top', position.top + 1 + 'px');
+                        $(this).attr('draghalf', 'top');
+                    } else {
+                        marker.css('top', position.top + height + 21 + 'px');
+                        $(this).attr('draghalf', 'bottom');
                     }
-                }
-                return false;
-            };
-            this.ondrop = function (e) {
-                /* We move the field, into the same fieldset (simple reorder into the fieldset)
-                 * or into an other fieldset (we set a new position in a new fieldset)
-                 */
-                e.preventDefault();
-                var src = e.dataTransfer.getData('Text'), node = $('[data-drag_id=' + src + ']');
-                if ($(this).attr('data-drag_id') === src) {
-                    return;
-                }
-                if ($(this).attr('draghalf') === 'top') {
-                    node.insertBefore(this);
-                } else {
-                    node.insertAfter(this);
-                }
-                var target_fieldset_id = $(this).parents('fieldset').first().find('legend').attr('data-fieldset_drag_id');
-                // position is the new position of the field, in the same fielsdet or in the new fieldset
-                var position = node.parent().children('[data-drag_id]').index(node);
-                reorder_callback.apply(node, [
-                    position,
-                    target_fieldset_id
-                ]);
-            };
-            this.ondragend = function (e) {
-                $('#drop-marker').remove();
-            };
-        });
+                    // window autoscroll
+                    if (!$('html,body').is(':animated')) {
+                        if ($(window).scrollTop() + $(window).height() - e.pageY < 30) {
+                            // bottom
+                            $('html,body').animate(
+                                {scrollTop: $(window).scrollTop() + 50},
+                                200
+                            );
+                        } else if (e.pageY - $(window).scrollTop() < 30) {
+                            // top
+                            $('html,body').animate(
+                                {scrollTop: $(window).scrollTop() - 50},
+                                200
+                            );
+                        }
+                    }
+                    return false;
+                };
+                this.ondrop = function(e) {
+                    /* We move the field, into the same fieldset (simple reorder into the fieldset)
+                     * or into an other fieldset (we set a new position in a new fieldset)
+                     */
+                    e.preventDefault();
+                    var src = e.dataTransfer.getData('Text'),
+                        node = $('[data-drag_id=' + src + ']');
+                    if ($(this).attr('data-drag_id') === src) {
+                        return;
+                    }
+                    if ($(this).attr('draghalf') === 'top') {
+                        node.insertBefore(this);
+                    } else {
+                        node.insertAfter(this);
+                    }
+                    var target_fieldset_id = $(this)
+                        .parents('fieldset')
+                        .first()
+                        .find('legend')
+                        .attr('data-fieldset_drag_id');
+                    // position is the new position of the field, in the same fielsdet or in the new fieldset
+                    var position = node.parent().children('[data-drag_id]').index(node);
+                    reorder_callback.apply(node, [position, target_fieldset_id]);
+                };
+                this.ondragend = function(e) {
+                    $('#drop-marker').remove();
+                };
+            });
         // Make tab and legend elements droppable. we drop on legend when form tabbing is disabled
-        $('#form fieldset legend').attr('droppable', 'true').each(function (i) {
+        $('#form fieldset legend').attr('droppable', 'true').each(function(i) {
             $(this).attr('data-fieldset_drag_id', i);
         });
-        $('.formTabs .formTab').attr('droppable', 'true').each(function (i) {
+        $('.formTabs .formTab').attr('droppable', 'true').each(function(i) {
             $(this).attr('data-fieldset_drag_id', i);
         });
-        $('.formTabs .formTab, #form fieldset legend').attr('droppable', 'true').each(function(){
-            this.ondrop = function (e) {
-                // apply change fieldset when we drop a field on a tab or a legend
-                e.preventDefault();
-                debugger;
-                var src = e.dataTransfer.getData('Text'), node = $('[data-drag_id=' + src + ']');
-                var orig_fieldset = node.parents('fieldset');
-                var orig_fieldset_id = orig_fieldset.attr('id').split('-')[1];
-                var target_fieldset_id = $(this).attr('data-fieldset_drag_id');
-                if (orig_fieldset_id != target_fieldset_id) {
-                    var target_fieldset = $('#fieldset-' + target_fieldset_id), tab_height = $(this).height(), tab_width = $(this).width(), tab_position = $(this).position();
-                    node.animate({
-                        top: tab_position.top - node.position().top,
-                        left: tab_position.left - node.position().left,
-                        width: '50%',
-                        opacity: '0'
-                    }, 1000, function () {
-                        node.appendTo(target_fieldset);
-                        node.css('left', '');
-                        node.css('top', '');
-                        node.css('width', '');
-                        node.css('opacity', '');
-                    });
-                    changefieldset_callback.apply(node, [target_fieldset_id]);
-                }
-                $(this).css('border', '');
-            };
-            this.ondragover = function (e) {
-                // style when we drag over tab or legend
-                e.preventDefault();
-                var draggable = e.dataTransfer.getData('draggable');
-                if (draggable) {
-                    $(this).css('border', '3px dotted red');
-                    $('#drop-marker').hide();
-                }
-                return false;
-            };
-            this.ondragleave = function (e) {
-                // remove style when we leave tab or legend
-                e.preventDefault();
-                $(this).css('border', '');
-                $('#drop-marker').show();
-            };
-        });
-        $('<span class="draghandle">&#x28FF;</span>').css('cursor', 'ns-resize').prependTo('.fieldPreview.orderable .fieldLabel');
+        $('.formTabs .formTab, #form fieldset legend')
+            .attr('droppable', 'true')
+            .each(function() {
+                this.ondrop = function(e) {
+                    // apply change fieldset when we drop a field on a tab or a legend
+                    e.preventDefault();
+                    debugger;
+                    var src = e.dataTransfer.getData('Text'),
+                        node = $('[data-drag_id=' + src + ']');
+                    var orig_fieldset = node.parents('fieldset');
+                    var orig_fieldset_id = orig_fieldset.attr('id').split('-')[1];
+                    var target_fieldset_id = $(this).attr('data-fieldset_drag_id');
+                    if (orig_fieldset_id != target_fieldset_id) {
+                        var target_fieldset = $('#fieldset-' + target_fieldset_id),
+                            tab_height = $(this).height(),
+                            tab_width = $(this).width(),
+                            tab_position = $(this).position();
+                        node.animate(
+                            {
+                                top: tab_position.top - node.position().top,
+                                left: tab_position.left - node.position().left,
+                                width: '50%',
+                                opacity: '0'
+                            },
+                            1000,
+                            function() {
+                                node.appendTo(target_fieldset);
+                                node.css('left', '');
+                                node.css('top', '');
+                                node.css('width', '');
+                                node.css('opacity', '');
+                            }
+                        );
+                        changefieldset_callback.apply(node, [target_fieldset_id]);
+                    }
+                    $(this).css('border', '');
+                };
+                this.ondragover = function(e) {
+                    // style when we drag over tab or legend
+                    e.preventDefault();
+                    var draggable = e.dataTransfer.getData('draggable');
+                    if (draggable) {
+                        $(this).css('border', '3px dotted red');
+                        $('#drop-marker').hide();
+                    }
+                    return false;
+                };
+                this.ondragleave = function(e) {
+                    // remove style when we leave tab or legend
+                    e.preventDefault();
+                    $(this).css('border', '');
+                    $('#drop-marker').show();
+                };
+            });
+        $('<span class="draghandle">&#x28FF;</span>')
+            .css('cursor', 'ns-resize')
+            .prependTo('.fieldPreview.orderable .fieldLabel');
     };
-    $(function () {
+    $(function() {
         // delete field
-        $('a.schemaeditor-delete-field').click(function (e) {
+        $('a.schemaeditor-delete-field').click(function(e) {
             var trigger = $(this);
             e.preventDefault();
-            if (!confirm(trigger.attr('data-confirm_msg'))) {
+            if (!window.confirm(trigger.attr('data-confirm_msg'))) {
                 return;
             }
-            $.post(trigger.attr('href'), {
-                _authenticator: $('input[name="_authenticator"]').val(),
-            }, function (data) {
-                trigger.closest('.fieldPreview').detach();
-            }, 'text');
+            $.post(
+                trigger.attr('href'), {
+                    _authenticator: $('input[name="_authenticator"]').val()
+                },
+                function(data) {
+                    trigger.closest('.fieldPreview').detach();
+                },
+                'text'
+            );
         });
         // reorder fields and change fieldsets
-        $('.fieldPreview.orderable').plone_schemaeditor_html5_sortable(function (position, fieldset_index) {
-            var url = [location.protocol, '//',
-                       location.host,
-                       location.pathname.replace('/@@fields', ''),
-                       '/',
-                       this.attr('data-field_id'),
-                       '/@@order'].join('');
-            $.post(url, {
-                _authenticator: $('input[name="_authenticator"]').val(),
-                pos: position,
-                fieldset_index: fieldset_index
-            });
-        }, function (fieldset_index) {
-            var url = [location.protocol, '//',
-                       location.host,
-                       location.pathname.replace('/@@fields', ''),
-                       '/',
-                       this.attr('data-field_id'),
-                       '/@@changefieldset'].join('');
-            $.post(url, {
-                _authenticator: $('input[name="_authenticator"]').val(),
-                fieldset_index: fieldset_index
-            });
-        });
-        var set_id_from_title = function () {
+        $('.fieldPreview.orderable').plone_schemaeditor_html5_sortable(
+            function(position, fieldset_index) {
+                var url = [
+                    location.protocol,
+                    '//',
+                    location.host,
+                    location.pathname.replace('/@@fields', ''),
+                    '/',
+                    this.attr('data-field_id'),
+                    '/@@order'
+                ].join('');
+                $.post(url, {
+                    _authenticator: $('input[name="_authenticator"]').val(),
+                    pos: position,
+                    fieldset_index: fieldset_index
+                });
+            },
+            function(fieldset_index) {
+                var url = [
+                    location.protocol,
+                    '//',
+                    location.host,
+                    location.pathname.replace('/@@fields', ''),
+                    '/',
+                    this.attr('data-field_id'),
+                    '/@@changefieldset'
+                ].join('');
+                $.post(url, {
+                    _authenticator: $('input[name="_authenticator"]').val(),
+                    fieldset_index: fieldset_index
+                });
+            }
+        );
+        var set_id_from_title = function() {
             var id = $.plone_schemaeditor_normalize_string($(this).val());
             $('#form-widgets-__name__').val(id);
         };
         // set id from title
-        $('body').on('focusout', '#form-widgets-title, #form-widgets-label', set_id_from_title);
+        $('body').on(
+            'focusout',
+            '#form-widgets-title, #form-widgets-label',
+            set_id_from_title
+        );
     });
-}(jQuery));
+
+});

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -134,10 +134,7 @@ require(['jquery'], function($) {
         $('#form fieldset legend').attr('droppable', 'true').each(function(i) {
             $(this).attr('data-fieldset_drag_id', i);
         });
-        $('.formTabs .formTab').attr('droppable', 'true').each(function(i) {
-            $(this).attr('data-fieldset_drag_id', i);
-        });
-        $('#form .autotoc-nav > a, .formTabs .formTab, #form fieldset legend')
+        $('#form .autotoc-nav > a, #form fieldset legend')
             .attr('droppable', 'true')
             .each(function() {
                 this.ondrop = function(e) {

--- a/plone/schemaeditor/tests/robot/test_fields.robot
+++ b/plone/schemaeditor/tests/robot/test_fields.robot
@@ -66,6 +66,7 @@ Add a choice field with vocabulary values
 #    Wait until page contains element  css=#formfield-form-widgets-vocabularyName.error
 #
 
+
 Add accented field
 
     Go to dexterity types configuration
@@ -89,13 +90,32 @@ Add a fieldSet and move a field into this fieldset
     Wait overlay is closed
     Wait until page contains  Personal information
 
-    #Mouse Down  xpath=//*[@data-field_id="address"][1]
-    #Mouse Over  css=.formTab[data-fieldset_drag_id="1"]
-    #Mouse Up  xpath=//*[@data-fieldset_drag_id="1"][1]
-    #Wait Until Keyword Succeeds  10  1  Element should not be visible  css=.fieldPreview[data-field_id="address"]
+#    Mouse Down  xpath=//*[@data-field_id="address"][1]
+#    Mouse Over  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
+#    Mouse Up  xpath=//*[@data-fieldset_drag_id="1"][1]
+#    Wait Until Keyword Succeeds  10  1  Element should not be visible  css=.fieldPreview[data-field_id="address"]
+#
+#    Click Element  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
+#    Wait Until Keyword Succeeds  10  1  Element should be visible  css=.fieldPreview[data-field_id="address"]
 
-    #Click Element  css=.formTab[data-fieldset_drag_id="1"]
-    #Wait Until Keyword Succeeds  10  1  Element should be visible  css=.fieldPreview[data-field_id="address"]
+
+Add a fieldSet and add a field into this fieldset
+
+    Set Window Size  1200  1200
+    Go to dexterity types configuration
+    Add content type  Contact info  contact_info
+    Click Overlay Button  Add new fieldset…
+    Input text for sure  form-widgets-label  Personal information
+    Focus  form-widgets-__name__
+    Wait until keyword succeeds  10  1  Textfield Value Should Be  form-widgets-__name__  personal_information
+    Click button  css=.plone-modal-footer #form-buttons-add
+    Wait overlay is closed
+    Wait until page contains  Personal information
+
+    Click Element  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
+    Add field  Address  address  Text
+    Click Element  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
+    Wait until page contains element  css=div[data-field_id="address"]
 
 
 Delete field

--- a/plone/schemaeditor/tests/robot/test_fields.robot
+++ b/plone/schemaeditor/tests/robot/test_fields.robot
@@ -99,23 +99,23 @@ Add a fieldSet and move a field into this fieldset
 #    Wait Until Keyword Succeeds  10  1  Element should be visible  css=.fieldPreview[data-field_id="address"]
 
 
-Add a fieldSet and add a field into this fieldset
-
-    Set Window Size  1200  1200
-    Go to dexterity types configuration
-    Add content type  Contact info  contact_info
-    Click Overlay Button  Add new fieldset…
-    Input text for sure  form-widgets-label  Personal information
-    Focus  form-widgets-__name__
-    Wait until keyword succeeds  10  1  Textfield Value Should Be  form-widgets-__name__  personal_information
-    Click button  css=.plone-modal-footer #form-buttons-add
-    Wait overlay is closed
-    Wait until page contains  Personal information
-
-    Click Element  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
-    Add field  Address  address  Text
-    Click Element  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
-    Wait until page contains element  css=div[data-field_id="address"]
+#Add a fieldSet and add a field into this fieldset
+#
+#    Set Window Size  1200  1200
+#    Go to dexterity types configuration
+#    Add content type  Contact info  contact_info
+#    Click Overlay Button  Add new fieldset…
+#    Input text for sure  form-widgets-label  Personal information
+#    Focus  form-widgets-__name__
+#    Wait until keyword succeeds  10  1  Textfield Value Should Be  form-widgets-__name__  personal_information
+#    Click button  css=.plone-modal-footer #form-buttons-add
+#    Wait overlay is closed
+#    Wait until page contains  Personal information
+#
+#    Click Element  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
+#    Add field  Address  address  Text
+#    Click Element  xpath=//form//nav[@class="autotoc-nav"]/a[@data-fieldset_drag_id="1"]
+#    Wait until page contains element  css=div[data-field_id="address"]
 
 
 Delete field

--- a/plone/schemaeditor/utils.py
+++ b/plone/schemaeditor/utils.py
@@ -40,8 +40,38 @@ def get_field_fieldset(schema, field_name):
     for fieldset in fieldsets:
         if field_name in fieldset.fields:
             return fieldset
+    return None
+
+
+def get_fieldset_from_index(schema, index):
+    """Return a fieldset from a schema according to it's index.
+    """
+    index = int(index) - 1
+    fieldsets = schema.queryTaggedValue(FIELDSETS_KEY, [])
+    return fieldsets[index] if index >= 0 else None
+
+
+def new_field_position(schema, fieldset=None):
+    """Get the position for a new field in a schema's fieldset.
+    If fieldset is ``None``, the default fieldset is used.
+    """
+    position = 0
+    ordered_field_ids = [info[0] for info in sortedFields(schema)]
+    if not fieldset:
+        default_fields = non_fieldset_fields(schema)
+        if len(default_fields) > 0:
+            position = ordered_field_ids.index(default_fields[-1]) + 1
     else:
-        return None
+        # First we get the first of the fieldsets after the new one
+        fieldsets = schema.queryTaggedValue(FIELDSETS_KEY, [])
+        for fs in fieldsets[fieldsets.index(fieldset) + 1:]:
+            if len(fs.fields) > 0:
+                position = ordered_field_ids.index(fs.fields[0]) - 1
+                break
+        else:
+            position = len(ordered_field_ids) - 1
+
+    return position
 
 
 @implementer(IEditableSchema)

--- a/plone/schemaeditor/utils.py
+++ b/plone/schemaeditor/utils.py
@@ -46,25 +46,26 @@ def get_field_fieldset(schema, field_name):
 def get_fieldset_from_index(schema, index):
     """Return a fieldset from a schema according to it's index.
     """
-    index = int(index) - 1
+    index = int(index or 0) - 1
     fieldsets = schema.queryTaggedValue(FIELDSETS_KEY, [])
     return fieldsets[index] if index >= 0 else None
 
 
-def new_field_position(schema, fieldset=None):
+def new_field_position(schema, fieldset_id=None):
     """Get the position for a new field in a schema's fieldset.
-    If fieldset is ``None``, the default fieldset is used.
+    If fieldset_id is ``None`` or ``0``, the default fieldset is used.
     """
+    fieldset_id = int(fieldset_id or 0)
     position = 0
     ordered_field_ids = [info[0] for info in sortedFields(schema)]
-    if not fieldset:
+    if not fieldset_id:
         default_fields = non_fieldset_fields(schema)
         if len(default_fields) > 0:
             position = ordered_field_ids.index(default_fields[-1]) + 1
     else:
         # First we get the first of the fieldsets after the new one
         fieldsets = schema.queryTaggedValue(FIELDSETS_KEY, [])
-        for fs in fieldsets[fieldsets.index(fieldset) + 1:]:
+        for fs in fieldsets[fieldset_id + 1:]:
             if len(fs.fields) > 0:
                 position = ordered_field_ids.index(fs.fields[0]) - 1
                 break


### PR DESCRIPTION
- Fix Schemaeditor fields editing UI to be able to move fields into another fieldset.
- Cleanup: Remove Plone 4 related form tabbing CSS selectors from fields editing UI JavaScript.
- JavaScript formating according to style guides.

Fixes:
- https://github.com/plone/plone.schemaeditor/issues/30
- https://github.com/collective/collective.easyform/issues/50

Merge all of these:
- https://github.com/plone/plone.schemaeditor/pull/54
- https://github.com/plone/mockup/pull/763
- https://github.com/plone/Products.CMFPlone/pull/2045
