### PR TITLE
Field reorderable, missing delete confirmation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix fields not being reorderable and missing their delete confirmation until a fieldset was added.
+  Fixes https://github.com/collective/collective.easyform/issues/81 and https://github.com/collective/collective.easyform/issues/82
+  [thet]
 
 
 2.0.17 (2017-05-23)

--- a/plone/schemaeditor/browser/schema/schemaeditor.js
+++ b/plone/schemaeditor/browser/schema/schemaeditor.js
@@ -275,14 +275,19 @@ require(['jquery'], function($) {
 
     $(document).ready(function() {
 
-        // Initialize only after autotoc has been initialized
-        if ($('#form .autotoc-nav > a').length) {
-            // pat-autotoc already initialized, script probably run after
-            // mockup initialization.
-            init_schemaeditor();
+        if ($('#form fieldset').length >= 2) {
+            // If multiple fieldsets, release after autotoc has been initialized
+            if ($('#form .autotoc-nav > a').length) {
+                // pat-autotoc already initialized, script probably run after
+                // mockup initialization.
+                init_schemaeditor();
+            } else {
+                // Otherwise, wait until autotoc is ready.
+                $(window).on('init.autotoc.patterns', init_schemaeditor);
+            }
         } else {
-            // Otherwise, wait until autotoc is ready.
-            $(window).on('init.autotoc.patterns', init_schemaeditor);
+            // If only one fieldset, initialize immediately
+            init_schemaeditor();
         }
 
     });


### PR DESCRIPTION
Fix fields not being reorderable and missing their delete confirmation until a fieldset was added.
Fixes https://github.com/collective/collective.easyform/issues/81 and https://github.com/collective/collective.easyform/issues/82