### PR TITLE
Fix getting vocabulary for multichoice fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Fix getting vocabulary for multichoice fields
+  [tomgross]
 
 2.0.18 (2017-08-30)
 -------------------

--- a/plone/schemaeditor/fields.py
+++ b/plone/schemaeditor/fields.py
@@ -258,7 +258,7 @@ class TextLineMultiChoiceField(TextLineChoiceField):
         field = self.field
         if name == 'values':
             values = []
-            for term in (self.field.vocabulary or []):
+            for term in (self.field.value_type.vocabulary or []):
                 if term.value != term.title:
                     values.append('{0:s}|{1:s}'.format(term.value, term.title))
                 else:


### PR DESCRIPTION
This bug was introduced with
https://github.com/plone/plone.schemaeditor/commit/dbfe9541b032ea62282d5facc5216ec7283d0715

and results in

https://github.com/collective/collective.easyform/issues/96