### PR TITLE
Default to a 4K x 4K browser window in Robot tests

### DIFF
--- a/news/66.bugfix
+++ b/news/66.bugfix
@@ -1,0 +1,3 @@
+- Use the shared 'Plone test setup' and 'Plone test teardown' keywords in Robot
+  tests.
+  [Rotonen]

--- a/plone/schemaeditor/tests/robot/test_fields.robot
+++ b/plone/schemaeditor/tests/robot/test_fields.robot
@@ -2,11 +2,12 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Run keywords  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Variables ***
 


### PR DESCRIPTION
I'm in the process of trying to unify Robot test setups and teardowns. This is a part of that effort.

Also re-enabled two previously disabled Robot tests.

In tandem with plone/plone.app.robotframework#110
Closes https://github.com/plone/plone.schemaeditor/issues/66

I also tried to revive the commented out tests, but those are just badly done and would require a rewrite. Despite tackling the stability of the Robot tests, I'm not actually well versed enough in Robot itself or the schema editor to try to redo those tests.