### PR TITLE
Added "Delete fieldset" functionality

### DIFF
--- a/news/69.feature
+++ b/news/69.feature
@@ -1,0 +1,1 @@
+Deleting fieldsets is now possible through the UI.

--- a/plone/schemaeditor/browser/schema/configure.zcml
+++ b/plone/schemaeditor/browser/schema/configure.zcml
@@ -24,6 +24,13 @@
     permission="plone.schemaeditor.ManageSchemata"
     />
 
+  <browser:page
+    name="delete-fieldset"
+    for="plone.schemaeditor.interfaces.ISchemaContext"
+    class=".delete_fieldset.DeleteFieldset"
+    permission="plone.schemaeditor.ManageSchemata"
+    />
+
   <browser:resource
     name="schemaeditor.js"
     file="schemaeditor.js"

--- a/plone/schemaeditor/browser/schema/delete_fieldset.py
+++ b/plone/schemaeditor/browser/schema/delete_fieldset.py
@@ -1,0 +1,43 @@
+from plone.schemaeditor import _
+from plone.schemaeditor.utils import SchemaModifiedEvent
+from plone.supermodel.interfaces import FIELDSETS_KEY
+from Products.Five import BrowserView
+from Products.statusmessages.interfaces import IStatusMessage
+from zope.container.contained import notifyContainerModified
+from zope.event import notify
+
+
+class DeleteFieldset(BrowserView):
+
+    def __call__(self):
+        fieldset_name = self.request.form.get('name')
+        schema = self.context.schema
+        fieldsets = schema.queryTaggedValue(FIELDSETS_KEY, [])
+
+        new_fieldsets = []
+        for fieldset in fieldsets:
+            if fieldset.__name__ == fieldset_name:
+                if fieldset.fields:
+                    IStatusMessage(self.request).addStatusMessage(
+                        _(u'Only empty fieldsets can be deleted'),
+                        type='error')
+                    return self.request.RESPONSE.redirect(self.nextURL)
+                continue
+            else:
+                new_fieldsets.append(fieldset)
+        if len(fieldsets) == len(new_fieldsets):
+            IStatusMessage(self.request).addStatusMessage(
+                _(u'Fieldset not found'), type='error')
+            return self.request.RESPONSE.redirect(self.nextURL)
+
+        schema.setTaggedValue(FIELDSETS_KEY, new_fieldsets)
+
+        notifyContainerModified(schema)
+        notify(SchemaModifiedEvent(self.context))
+        IStatusMessage(self.request).addStatusMessage(
+            _(u'Fieldset deleted successfully.'), type='info')
+        return self.request.RESPONSE.redirect(self.nextURL)
+
+    @property
+    def nextURL(self):
+        return self.request.get('HTTP_REFERER')

--- a/plone/schemaeditor/browser/schema/schema_listing.pt
+++ b/plone/schemaeditor/browser/schema/schema_listing.pt
@@ -82,6 +82,11 @@
           <legend tal:define="group_name python:group.label or view.default_fieldset_label"
                   tal:content="group_name">Fieldset name</legend>
 
+          <a id="delete-fieldset-${fieldset_name}" tal:condition="python:context.enableFieldsets and group.__name__ != view.__name__"
+             href="${context/absolute_url}/@@delete-fieldset?name=${python:group.__name__}&_authenticator=${context/@@authenticator/token}"
+                  i18n:translate="delete_fieldset_hellip">Delete fieldset
+          </a>
+
           <tal:block tal:define="errors group/widgets/errors"
                      tal:condition="errors"
                      tal:repeat="error errors">

--- a/plone/schemaeditor/tests/editing.rst
+++ b/plone/schemaeditor/tests/editing.rst
@@ -342,6 +342,37 @@ Now the actual IDummySchema schema should have the new fieldset ::
     [<Fieldset 'alpha'...of fieldA>, <Fieldset 'extra_info'...of >]
 
 
+Deleting a fieldset
+-------------------
+
+We can also delete a fieldset, but only if it's empty. Say we've moved a field to the new fieldset ::
+
+    >>> browser.open('http://nohost/@@schemaeditor/field3/@@changefieldset?fieldset_index=2')
+    [event: ContainerModifiedEvent on InterfaceClass]
+    [event: SchemaModifiedEvent on DummySchemaContext]
+
+If we try deleting the fieldset now, it won't work ::
+
+    >>> browser.open(portal_url + '/@@schemaeditor')
+    >>> browser.getLink(id='delete-fieldset-2').click()
+    >>> IDummySchema.getTaggedValue(FIELDSETS_KEY)
+    [<Fieldset 'alpha'...of fieldA>, <Fieldset 'extra_info'...of field3>]
+
+If we move the field out so that the fieldset is empty then we can delete the fieldset ::
+
+    >>> browser.open('http://nohost/@@schemaeditor/field3/@@changefieldset?fieldset_index=0')
+    [event: ContainerModifiedEvent on InterfaceClass]
+    [event: SchemaModifiedEvent on DummySchemaContext]
+    >>> browser.open(portal_url + '/@@schemaeditor')
+    >>> browser.getLink(id='delete-fieldset-2').click()
+    [event: ContainerModifiedEvent on InterfaceClass]
+    [event: SchemaModifiedEvent on DummySchemaContext]
+
+This removes the fieldset from the IDummySchema schema ::
+
+    >>> IDummySchema.getTaggedValue(FIELDSETS_KEY)
+    [<Fieldset 'alpha'...of fieldA>]
+
 Miscellaneous field types
 -------------------------
 


### PR DESCRIPTION
Allows deleting empty fieldsets.

Why only empty ones? It seems a bit risky to delete all contained fields because there is no undo. Besides, I can't think of a use case where I wanted to delete a whole fieldset including all its fields. The main use case is probably that a fieldset becomes obsolete because all fields have been deleted or move to another one anyway. As long as there's no possibility to edit a fieldset this can also serve as a workaround for renaming - create a new fieldset, move over the fields, delete the old one.

Refs #69
