### PR TITLE
Ignore validation errors for "required" when saving defaults

### DIFF
--- a/news/71.bugfix
+++ b/news/71.bugfix
@@ -1,0 +1,1 @@
+Don't show an error when a "required" field doesn't have a default. Also added a "Done" button.

--- a/plone/schemaeditor/browser/schema/listing.py
+++ b/plone/schemaeditor/browser/schema/listing.py
@@ -105,10 +105,18 @@ class SchemaListing(AutoExtensibleForm, form.Form):
         return url
 
     @button.buttonAndHandler(
+        _(u'Done'),
+    )
+    def handleDone(self, action):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+    @button.buttonAndHandler(
         _(u'Save Defaults'),
         condition=lambda form: getattr(form.context, 'showSaveDefaults', True)
     )
     def handleSaveDefaults(self, action):
+        for group in self.groups:
+            group.ignoreRequiredOnExtract = self.ignoreRequiredOnExtract
         data, errors = self.extractData()
         if errors:
             self.status = self.formErrorsMessage


### PR DESCRIPTION
Also added a "Done" button that leaves the field edit view.
Refs #71