### PR TITLE
Makes test Add a choice field with a named vocabulary more robust

### DIFF
--- a/plone/schemaeditor/tests/robot/test_fields.robot
+++ b/plone/schemaeditor/tests/robot/test_fields.robot
@@ -33,8 +33,8 @@ Add a choice field with a named vocabulary
     Focus  form-widgets-__name__
     Wait until keyword succeeds  10  1  Textfield Value Should Be  form-widgets-__name__  languages
     Input text for sure  form-widgets-description  Spoken languages
-    Select from list  form-widgets-factory  Multiple Choice
-    Click button  css=.plone-modal-footer #form-buttons-add
+    Wait until keyword succeeds  10  1  Select From List By Label  form-widgets-factory  Multiple Choice
+    Wait until keyword succeeds  10  1  Click button  css=.plone-modal-footer #form-buttons-add
     Wait until page contains element  css=div[data-field_id="languages"] a.fieldSettings
 
     Open field settings  languages

--- a/plone/schemaeditor/tests/robot/test_fields.robot
+++ b/plone/schemaeditor/tests/robot/test_fields.robot
@@ -182,4 +182,6 @@ Add field
 
 Open field settings
     [Arguments]    ${field_id}
-    Click Overlay Link  xpath=//div[@data-field_id='${field_id}']//a[@class='fieldSettings pat-plone-modal']
+    ${locator}  Set Variable  //div[@data-field_id='${field_id}']//a[@class='fieldSettings pat-plone-modal']
+    Wait until element is visible  xpath=${locator}
+    Click Overlay Link  xpath=${locator}


### PR DESCRIPTION
This test fails randomly. Sometimes the keyword doesn't give an error but doesn't do what it should. Now, in case of an error, we try again.

This try fix:

```bash
==============================================================================
Test Fields                                                                   
==============================================================================
Add a choice field with a named vocabulary                            | FAIL |
Element 'css=div[data-field_id="languages"] a.fieldSettings' did not appear in 30 seconds.
------------------------------------------------------------------------------
Test Fields                                                           | FAIL |
1 critical test, 0 passed, 1 failed
1 test total, 0 passed, 1 failed
==============================================================================
Output:  /home/jenkins/workspace/pull-request-5.2-2.7/parts/test/test_fields/Add_a_choice_field_with_a_named_vocabulary/output.xml



Failure in test Add a choice field with a named vocabulary (test_fields.robot)
Traceback (most recent call last):
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/jenkins/.buildout/eggs/cp27m/robotsuite-2.2.1-py2.7.egg/robotsuite/__init__.py", line 475, in runTest
    assert last_status == 'PASS', last_message
AssertionError: Element 'css=div[data-field_id="languages"] a.fieldSettings' did not appear in 30 seconds.
```

See: https://jenkins.plone.org/job/pull-request-5.2-2.7/2014/