### PR TITLE
Fix incomplete validation error for invalid field name.

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,3 @@
+Fix incomplete validation error for invalid field name.
+According to the regular expression, a field must start with a lowercase character.
+[maurits]

--- a/plone/schemaeditor/interfaces.py
+++ b/plone/schemaeditor/interfaces.py
@@ -146,8 +146,8 @@ ID_RE = re.compile(r'^[a-z][\w\d\.]*$')
 def isValidFieldName(value):
     if not ID_RE.match(value):
         raise Invalid(
-            _(u'Please use only letters, numbers and the following '
-              u'characters: _.')
+            _(u'Please start with a lowercase letter and after this use only letters, '
+              u'numbers and the following characters: _.')
         )
     if value in RESERVED_NAMES:
         raise Invalid(

--- a/plone/schemaeditor/tests/editing.rst
+++ b/plone/schemaeditor/tests/editing.rst
@@ -327,7 +327,7 @@ Let's add a 'extra-info' fieldset to the IDummySchema schema::
     >>> browser.getControl('Short Name').value = 'extra-info'
     >>> browser.getControl('Add').click()
     >>> browser.contents
-    '<...Please use only letters, numbers and the following characters...'
+    '<...Please start with a lowercase letter and after this use only letters, numbers and the following characters...'
     >>> browser.getControl('Short Name').value = 'extra_info'
     >>> browser.getControl('Add').click()
     [event: ContainerModifiedEvent on InterfaceClass]


### PR DESCRIPTION
According to the regular expression, a field must start with a lowercase character.
I am not sure this is really needed.  But now the validation error matches the expression.
I got a question from a customer about this.