### PR TITLE
Fix intermittent error in test robot `Scenario: Add a fieldSet and move a field into this fieldset`

### DIFF
--- a/news/159.internal
+++ b/news/159.internal
@@ -1,0 +1,1 @@
+Fix intermittent error in test robot `Scenario: Add a fieldSet and move a field into this fieldset`. @wesleybl

--- a/src/plone/schemaeditor/tests/robot/test_fields.robot
+++ b/src/plone/schemaeditor/tests/robot/test_fields.robot
@@ -160,6 +160,9 @@ I add a new field
     Type Text    //textarea[@name="form.widgets.description"]    my description of the field
     Select Options By    //select[@name="form.widgets.factory:list"]    label    ${FIELD_TYPE}
     Click    //div[contains(@class,"modal-footer")]//button[@id="form-buttons-add"]
+    the overlay is closed
+    Get Text    //*[@id="global_statusmessage"]    contains    Field added successfully.
+    Get Element Count    //div[@data-field_id="${FIELD_ID}"]//a[contains(text(),'Settings…')]    should be    1
 
 I add a new fieldset
     [Arguments]    ${FIELDSET_LABEL}    ${FIELDSET_ID}


### PR DESCRIPTION
It waits for the operation to add a new field before proceeding.

Fix: https://jenkins.plone.org/job/pull-request-6.2-3.14/227/robot/report/robot_log.html#s1-s2